### PR TITLE
support autofocus for multiselect

### DIFF
--- a/packages/admin/src/types/TypeMultiselect.vue
+++ b/packages/admin/src/types/TypeMultiselect.vue
@@ -262,6 +262,14 @@ export default TypeComponent.register('multiselect', {
     }
   },
 
+  mounted() {
+    if (this.autofocus) {
+      // vue-multiselect doesn't support the autofocus attribute. We need to
+      // handle it here.
+      this.focus()
+    }
+  },
+
   methods: {
     addTagOption(tag) {
       if (this.taggable) {


### PR DESCRIPTION
`autofocus` seems to already be handled for "native" inputs through the `autofocus` attribute. The `multiselect` componend didn't support it. This PR adds that support.

It should work the same as the html `autofocus` attribute: If the value is changed after the input is created, focus is not gained.