### PR TITLE
add defaultOrder schema property for lists

### DIFF
--- a/packages/admin/src/components/DitoTreeItem.vue
+++ b/packages/admin/src/components/DitoTreeItem.vue
@@ -244,6 +244,7 @@ export default DitoComponent.component('dito-tree-item', {
           }
         }) || []
       }
+      return undefined
     },
 
     details() {

--- a/packages/admin/src/mixins/SourceMixin.js
+++ b/packages/admin/src/mixins/SourceMixin.js
@@ -122,9 +122,17 @@ export default {
       return isView ? path : `${path}/${this.schema.path}`
     },
 
+    // This can be overridden by components that use this mixin.
+    defaultQuery() {
+      return {}
+    },
+
     query: {
       get() {
-        return this.getStore('query') || {}
+        return {
+          ...this.defaultQuery,
+          ...this.getStore('query')
+        }
       },
 
       set(query) {
@@ -182,6 +190,7 @@ export default {
         }
         return first
       }
+      return undefined
     },
 
     nestedMeta() {

--- a/packages/admin/src/types/TypeList.vue
+++ b/packages/admin/src/types/TypeList.vue
@@ -196,6 +196,15 @@ export default TypeComponent.register([
       return this.isListSource && this.inline &&
         // If there are only compact forms with no labels, don't add spacing
         (!this.isCompact || this.hasLabels)
+    },
+
+    defaultQuery() {
+      const { defaultOrder, defaultOrderDirection } = this.schema
+      return defaultOrder
+        ? {
+          order: `${defaultOrder} ${defaultOrderDirection || 'asc'}`
+        }
+        : {}
     }
   },
 


### PR DESCRIPTION
I'm not sure if this is the right way to do this.

The `return undefined` additions were added because linter failed without them.