### PR TITLE
Add admin UI build option disableHmr

### DIFF
--- a/packages/server/src/controllers/AdminController.js
+++ b/packages/server/src/controllers/AdminController.js
@@ -59,7 +59,7 @@ export class AdminController extends Controller {
         publicPath: '/',
         stats
       },
-      hotClient: {
+      hotClient: !config.build.disableHotReload && {
         stats
       }
     })


### PR DESCRIPTION
Same logic as the build.disable flag to completely disable build.

By default hot module reloading is enabled as it previously always was