### PR TITLE
Support if on tab schemas

### DIFF
--- a/packages/admin/src/components/DitoTabs.vue
+++ b/packages/admin/src/components/DitoTabs.vue
@@ -2,6 +2,7 @@
   .dito-tabs
     router-link.dito-link(
       v-for="(tabSchema, key) in tabs"
+      v-if="shouldRender(tabSchema)"
       :key="key"
       :to="{ hash: key }"
       active-class="dito-active"


### PR DESCRIPTION
I was aiming to hide a tab by adding `if: ({ formComponent }) => formComponent.isCreating` to the tab schema and noticed it didn't have any effect. This pr fixes that (although you can in theory still visit the tab by adding the hash id after the url - not sure if that is an issue).