### PR TITLE
Fix displaying of 0 in table cells

### DIFF
--- a/packages/admin/src/components/DitoTableCell.vue
+++ b/packages/admin/src/components/DitoTableCell.vue
@@ -65,7 +65,7 @@ export default DitoComponent.component('dito-table-cell', {
             dataPath: appendDataPath(this.dataPath, name)
           })
         )
-        : escapeHtml(value)
+        : escapeHtml(value?.toString())
     }
   }
 })


### PR DESCRIPTION
When `value = 0`, `escapeHtml(value)` was returning empty string, because `0` is falsy.