### PR TITLE
Don't return result when the validation fails.

### DIFF
--- a/packages/server/src/controllers/ControllerAction.js
+++ b/packages/server/src/controllers/ControllerAction.js
@@ -187,9 +187,20 @@ export default class ControllerAction {
         await this.returns.validate(data)
         return getResult()
       } catch (error) {
+        // Include full JSON result in responses during tests and development,
+        // for easier debugging.
+        const message =
+          process.env.NODE_ENV === 'test' ||
+          process.env.NODE_ENV === 'development'
+            ? `Invalid result of action: ${JSON.stringify(
+                getResult(),
+                null,
+                2
+              )}`
+            : 'Invalid result of action'
         throw this.createValidationError({
           type: 'ResultValidation',
-          message: `Invalid result of action: ${JSON.stringify(getResult())}`,
+          message,
           errors: error.errors
         })
       }


### PR DESCRIPTION
This validation is sometimes used to prevent leaking data, for example when using the wrong scope or graph. When such an problem occurs, the result should be sent to the client.