### PR TITLE
Fix Json encoding of Models

### DIFF
--- a/packages/server/src/models/Model.js
+++ b/packages/server/src/models/Model.js
@@ -580,17 +580,6 @@ export class Model extends objection.Model {
   // @override
   $formatJson(json) {
     const { constructor } = this
-    // Calculate and set the computed properties.
-    for (const key of constructor.computedAttributes) {
-      // Perhaps the computed property is produced in the SQL statement,
-      // in which case we don't have to do anything anymore here.
-      if (!(key in json)) {
-        const value = this[key]
-        if (value !== undefined) {
-          json[key] = value
-        }
-      }
-    }
     // Remove hidden attributes.
     for (const key of constructor.hiddenAttributes) {
       delete json[key]


### PR DESCRIPTION
Objection's `modelToJson.js` already takes care of setting the computed attribute to the external Json because dito overrides `static get virtualAttributes()`.
Before the fix, they were computed twice.
This also simplifies removing `hidden` attributes from the external Json, as well as removing the `computed` attribute from the Database Json.

`toJson` and `toDatabaseJson` have been tested manually.