### PR TITLE
Manually commit the session

### DIFF
--- a/packages/server/src/app/Application.js
+++ b/packages/server/src/app/Application.js
@@ -571,7 +571,14 @@ export class Application extends Koa {
         // eslint-disable-next-line new-cap
         options.ContextStore = SessionStore(modelClass)
       }
+      options.autoCommit = false
       this.use(session(options, this))
+      // Manually commit the session after the route has been handled without
+      // errors.
+      this.use(async (ctx, next) => {
+        await next()
+        await ctx.session.manuallyCommit()
+      })
     }
     // 6. passport
     if (app.passport) {


### PR DESCRIPTION
When autoCommit is set to TRUE, the session is committed even when an error occurs (in finally block). In the case that the DB decides to rollback the transaction (when a constraint is violated for example) the session should not be committed. Doing so will cause an other exception (because the transaction is aborted) and the original error will be lost.