### PR TITLE
Fix resolving typescript files

### DIFF
--- a/packages/server/src/controllers/AdminController.js
+++ b/packages/server/src/controllers/AdminController.js
@@ -259,7 +259,7 @@ export class AdminController extends Controller {
             ]
           },
           resolve: {
-            extensions: ['.js', '.json', '.vue'],
+            extensions: ['.js', '.json', '.ts', '.vue'],
             preserveSymlinks: true,
             alias: [
               {


### PR DESCRIPTION
I wasn't able to build my typescript project using the latest version – I was seeing errors like

`RollupError: Could not resolve "./page" from "src/admin/views/pages/index.ts"`

This pr fixes this issue.