### PR TITLE
update isUrl to support single-character domain names (like x.com)

### DIFF
--- a/packages/utils/src/string/isUrl.js
+++ b/packages/utils/src/string/isUrl.js
@@ -8,7 +8,7 @@ const isUrlRegExp = new RegExp(
   '(\\d{1,3}\\.){3}\\d{1,3}' + // ip
   '|' +
   '([0-9a-z_-]+\\.)*' + // sub-domain: www.
-  '[0-9a-z][0-9a-z_-]{0,61}[0-9a-z]\\.' + // domain-name
+  '[0-9a-z](?:[0-9a-z_-]{0,61}[0-9a-z])?\\.' + // domain-name
   // tld - https://tools.ietf.org/id/draft-liman-tld-names-00.html#rfc.section.2
   '([a-z]{2,61}|xn--[0-9a-z][0-9a-z-]{0,61}[0-9a-z])' +
   ')' + // top level domain.

--- a/packages/utils/src/string/isUrl.test.js
+++ b/packages/utils/src/string/isUrl.test.js
@@ -33,7 +33,8 @@ describe('isUrl()', () => {
     'http://foo--bar.com',
     'http://xn--j1aac5a4g.xn--j1amh',
     'http://xn------eddceddeftq7bvv7c4ke4c.xn--p1ai',
-    'test.com?ref=http://test2.com'
+    'test.com?ref=http://test2.com',
+    'x.com'
     // TODO: Support unicode URLs
     // 'http://høyfjellet.no',
     // 'http://кулік.укр',


### PR DESCRIPTION
This PR modifies the regular expression used in `isUrl` to allow single-character domain names (e.g., `x.com`).

#### Details

The original regex required domain names to have at least two characters due to the following pattern:

```
\[0-9a-z\]\[0-9a-z_-]{0,61}\[0-9a-z\]
```

- The first `[0-9a-z]` ensured the domain started with an alphanumeric character.
- The middle part `[0-9a-z_-]{0,61}` allowed up to 61 additional characters, including hyphens or underscores.
- The final `[0-9a-z]` ensured the domain ended with an alphanumeric character, preventing domains from ending with hyphens or underscores.

#### The Change

To allow for single-character domain names while preserving the original constraints, the regex was modified to:

```
\[0-9a-z\](?:\[0-9a-z_-]{0,61}\[0-9a-z\])?
```

- The first `[0-9a-z]` still ensures the domain starts with an alphanumeric character.
- The middle part `(?:[0-9a-z_-]{0,61}[0-9a-z])?` is now a **non-capturing group** and made **optional** with the `?`, allowing for a single-character domain name when the group is omitted.
- This change ensures domains like `x.com` are valid while still preventing invalid domains such as `-ok.com` or `ok-.com`.

#### Testing

- Verified the regex works for the following cases:
  - ✅ Valid: `x.com`, `example.com`, `ex-am-ple.com`
  - ❌ Invalid: `-ok.com`, `ok-.com`
