### PR TITLE
Fix types not being found

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "import": "./dist/dito-admin.es.js",
-      "require": "./dist/dito-admin.umd.js"
+      "require": "./dist/dito-admin.umd.js",
+      "types": "./types/index.d.ts"
     },
     "./style.css": "./dist/style.css",
     "./src": "./src/index.js",
@@ -87,5 +88,5 @@
     "typescript": "^5.6.3",
     "vite": "^5.4.8"
   },
-  "types": "types"
+  "types": "./types/index.d.ts"
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -88,5 +88,5 @@
     "objection": "^3.1.5",
     "typescript": "^5.6.3"
   },
-  "types": "types"
+  "types": "./types/index.d.ts"
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,7 +8,11 @@
   "license": "MIT",
   "main": "./src/index.js",
   "exports": {
-    ".": "./src/index.js"
+    ".": {
+      "import": "./src/index.js",
+      "require": "./src/index.js",
+      "types": "./types/index.d.ts"
+    }
   },
   "files": [
     "src/",
@@ -34,5 +38,5 @@
   "devDependencies": {
     "typescript": "^5.6.3"
   },
-  "types": "types"
+  "types": "./types/index.d.ts"
 }


### PR DESCRIPTION
While upgrading to Node 22 icw pnpm I ran into a few issues where the Dito types weren't being found. This pr fixes things.