### PR TITLE
Tests: Add admin e2e foundation + crud round-trip

### DIFF
--- a/tests/e2e/crud/admin/index.spec.ts
+++ b/tests/e2e/crud/admin/index.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '../fixtures.js'
+import {
+  AdminListPage,
+  DitoForm
+} from '../../../utils/pages.js'
+
+test.describe('crud', () => {
+  // Warm the admin Vite bundle once per worker. The first navigation to a
+  // new admin route triggers on-demand compilation that can exceed
+  // per-test timeouts on CI cold starts.
+  test.beforeAll(async ({ browser, url }) => {
+    const page = await browser.newPage()
+    try {
+      await page.goto(`${url}/admin/widgets`, {
+        waitUntil: 'networkidle'
+      })
+    } finally {
+      await page.close()
+    }
+  })
+
+  test('create, edit, delete round-trip', async ({ page, url }) => {
+    const list = new AdminListPage(page, url, 'Widget')
+    const form = new DitoForm(page)
+
+    // Navigate. The Create button is a stable readiness signal — it's
+    // always rendered when the list view is mounted, regardless of row
+    // count. The empty table itself can register as "hidden" (zero
+    // height), so we don't assert on it directly.
+    await list.navigate('/widgets')
+    await expect(
+      page.getByRole('button', { name: 'Create', exact: true })
+    ).toBeVisible()
+
+    // Create — submit closes the form automatically (Dito's submit-button
+    // schema defaults to closeForm: true), so we don't call clickButton
+    // ('Close') after Create/Save.
+    await list.list.create()
+    await form.fill('Name', 'A')
+    await form.create()
+    await expect(list.list.getRow('A')).toBeVisible()
+
+    // Edit.
+    await list.list.edit('A')
+    await form.fill('Name', 'B')
+    await form.save()
+    await expect(list.list.getRow('B')).toBeVisible()
+    await expect(list.list.getRow('A')).not.toBeVisible()
+
+    // Delete.
+    await list.list.delete('B')
+    await expect(list.list.getRow('B')).not.toBeVisible()
+  })
+})

--- a/tests/e2e/crud/app/index.html
+++ b/tests/e2e/crud/app/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <style>body, html { height: 100%; margin: 0; }</style>
+  </head>
+  <body>
+    <div id="dito-admin"></div>
+    <script type="module" src="/index.ts"></script>
+  </body>
+</html>

--- a/tests/e2e/crud/app/index.ts
+++ b/tests/e2e/crud/app/index.ts
@@ -1,0 +1,7 @@
+import DitoAdmin from '@ditojs/admin'
+import '@ditojs/admin/style.css'
+
+new DitoAdmin('#dito-admin', {
+  dito,
+  views: import('./views/index.js')
+})

--- a/tests/e2e/crud/app/views/index.ts
+++ b/tests/e2e/crud/app/views/index.ts
@@ -1,0 +1,16 @@
+import type { Widget } from '../../models/Widget.js'
+import { createWidgetView } from
+  '../../../schema-components/app/views/createWidgetView.js'
+
+export const widgets = createWidgetView<Widget>(
+  'Widget',
+  'widgets',
+  {
+    name: { type: 'text', label: 'Name' }
+  },
+  {
+    creatable: true,
+    deletable: true,
+    columns: { name: { label: 'Name' } }
+  }
+)

--- a/tests/e2e/crud/fixtures.ts
+++ b/tests/e2e/crud/fixtures.ts
@@ -1,0 +1,29 @@
+import path from 'path'
+import { AdminController, ModelController } from '@ditojs/server'
+import {
+  createFixtureAppFixture,
+  createModelHelpers
+} from '../../utils/fixture-app.js'
+import { Widget } from './models/Widget.js'
+
+export { expect } from '@playwright/test'
+export { createModelHelpers }
+
+class Widgets extends ModelController {
+  override modelClass = Widget
+  collection = {
+    allow: ['get', 'post'] as const
+  }
+  member = {
+    allow: ['get', 'patch', 'delete'] as const
+  }
+}
+
+export const test = createFixtureAppFixture({
+  appRoot: path.resolve(import.meta.dirname, 'app'),
+  models: { Widget },
+  controllers: {
+    admin: AdminController,
+    api: { Widgets }
+  }
+})

--- a/tests/e2e/crud/models/Widget.ts
+++ b/tests/e2e/crud/models/Widget.ts
@@ -1,0 +1,16 @@
+import type { ModelProperties } from '@ditojs/server'
+import { Model } from '@ditojs/server'
+
+export interface Widget {
+  id: number
+  name: string
+}
+
+export class Widget extends Model {
+  static override properties: ModelProperties = {
+    name: {
+      type: 'string',
+      required: true
+    }
+  }
+}

--- a/tests/e2e/schema-components/app/views/createWidgetView.ts
+++ b/tests/e2e/schema-components/app/views/createWidgetView.ts
@@ -5,7 +5,8 @@ import type {
 export function createWidgetView<T>(
   itemLabel: string,
   resource: string,
-  components: Components<T>
+  components: Components<T>,
+  listOptions: Record<string, unknown> = {}
 ): ViewSchema<T> {
   return {
     type: 'view',
@@ -14,7 +15,8 @@ export function createWidgetView<T>(
       itemLabel,
       resource: { path: resource },
       editable: true,
-      form: { type: 'form', components }
+      form: { type: 'form', components },
+      ...listOptions
     }
   }
 }

--- a/tests/utils/fixture-app.ts
+++ b/tests/utils/fixture-app.ts
@@ -1,0 +1,102 @@
+import { test as base, type Page } from '@playwright/test'
+import type { Model } from '@ditojs/server'
+import {
+  createTestApp,
+  getAppUrl,
+  stubSession
+} from './app.js'
+import { createTestDatabase } from './database.js'
+import { waitForUrl } from './net.js'
+
+export interface FixtureAppOptions {
+  /** Absolute path to the scenario's `app/` directory (the admin entrypoint). */
+  appRoot: string
+  /** Models to register on the embedded app. */
+  models: Record<string, typeof Model>
+  /** Controllers to register on the embedded app. */
+  controllers: Record<string, unknown>
+  /** Optional extra config merged into `createTestApp`'s `config`. */
+  config?: Record<string, unknown>
+}
+
+/**
+ * Returns a Playwright test object whose worker fixture spins up an
+ * embedded Dito app (PGlite-backed, Vite-served admin) and exposes its
+ * `url`. Mirrors the boilerplate in `tests/e2e/assets/fixtures.ts`.
+ */
+export function createFixtureAppFixture(opts: FixtureAppOptions) {
+  return base.extend<{ url: string }, { workerUrl: string }>({
+    workerUrl: [
+      async ({}, use) => {
+        const app = createTestApp({
+          models: opts.models,
+          controllers: opts.controllers,
+          admin: {
+            root: opts.appRoot,
+            api: { url: '/api/' }
+          },
+          config: opts.config
+        })
+
+        stubSession(app)
+        await createTestDatabase(app)
+        await app.start()
+        const url = getAppUrl(app)
+        await waitForUrl(`${url}/admin/`)
+
+        await use(url)
+
+        // Suppress errors during teardown — closing connections triggers
+        // expected "Premature close" errors from in-flight responses.
+        app.off('error', app.logError)
+        app.server?.closeAllConnections()
+        await app.stop()
+        await app.knex?.destroy()
+      },
+      { scope: 'worker' }
+    ],
+
+    url: async ({ workerUrl }, use) => {
+      await use(workerUrl)
+    }
+  })
+}
+
+/**
+ * Returns `seed` and `saveAndFetch` helpers for a model + REST resource.
+ * Relocated from `tests/e2e/assets/fixtures.ts`.
+ */
+export function createModelHelpers<M extends typeof Model>(
+  ModelClass: M,
+  resource: string,
+  defaults: Record<string, unknown> = {}
+) {
+  async function seed(data: Record<string, unknown> = {}) {
+    const instance = await ModelClass.query().insert({ ...defaults, ...data })
+    return instance.$id() as number
+  }
+
+  async function saveAndFetch(
+    page: Page,
+    id: number
+  ): Promise<InstanceType<M>> {
+    const saved = page.waitForResponse(
+      resp =>
+        resp.url().includes(`/api/${resource}/${id}`) &&
+        resp.request().method() === 'PATCH' &&
+        resp.ok()
+    )
+    await page
+      .locator('button.dito-button[type="submit"]')
+      .first()
+      .click()
+    await saved
+    const instance = await ModelClass.query().findById(id)
+    if (!instance) {
+      throw new Error(`${ModelClass.name} ${id} not found`)
+    }
+    return instance as InstanceType<M>
+  }
+
+  return { seed, saveAndFetch }
+}

--- a/tests/utils/pages.ts
+++ b/tests/utils/pages.ts
@@ -1,0 +1,378 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+
+// Dito multiselect uses role=combobox + role=option in a portal. Option click
+// targets `page` (portal root), combobox can be scoped to any container.
+export async function fillDitoMultiselect(
+  page: Page,
+  scope: Locator | Page,
+  label: string,
+  search: string,
+  option?: string
+) {
+  const combobox = scope.getByRole('combobox', { name: label })
+  await combobox.click()
+  await combobox.locator('input').fill(search)
+  // Exact so e.g. "Cyrillic" doesn't also match "Latin & Cyrillic".
+  await page
+    .getByRole('option', { name: option ?? search, exact: true })
+    .click()
+}
+
+export class DitoList {
+  readonly table: Locator
+
+  constructor(
+    private readonly page: Page,
+    private readonly label: string
+  ) {
+    this.table = page.getByRole('region', { name: label }).getByRole('table')
+  }
+
+  get rows() {
+    return this.table.locator('tbody tr')
+  }
+
+  getRow(text: string) {
+    // Match a body row that contains a cell whose accessible name is
+    // exactly `text`. Avoids substring/header-row collisions that
+    // `hasText` would cause (e.g. `getRow('A')` substring-matching the
+    // header cell "Name").
+    return this.rows.filter({
+      has: this.page.getByRole('cell', { name: text, exact: true })
+    })
+  }
+
+  async edit(text: string) {
+    await this.getRow(text).getByRole('link', { name: 'Edit' }).click()
+  }
+
+  async editFirst() {
+    await this.rows.first().getByRole('link', { name: 'Edit' }).click()
+  }
+
+  async editAt(index: number) {
+    await this.rows.nth(index).getByRole('link', { name: 'Edit' }).click()
+  }
+
+  async delete(text: string) {
+    const row = this.getRow(text)
+    await row.hover()
+    // Dito's SourceMixin.deleteItem calls window.confirm. Playwright
+    // auto-dismisses dialogs by default, so register a one-shot accept
+    // handler before triggering the delete.
+    this.page.once('dialog', dialog => dialog.accept())
+    const deleted = this.page
+      .waitForResponse(
+        resp =>
+          resp.request().method() === 'DELETE' &&
+          /\/api\//.test(resp.url()) &&
+          resp.ok(),
+        { timeout: 5_000 }
+      )
+      .catch(() => null)
+    await row.getByRole('button', { name: 'Delete' }).click()
+    await deleted
+  }
+
+  async create() {
+    await this.page.getByRole('button', { name: 'Create', exact: true }).click()
+  }
+
+  async selectScope(name: string) {
+    await this.page.getByRole('button', { name, exact: true }).click()
+  }
+
+  async getCell(rowText: string, columnName: string): Promise<Locator> {
+    const headers = this.table.locator('thead tr th')
+    const count = await headers.count()
+    for (let i = 0; i < count; i++) {
+      const text = await headers.nth(i).textContent()
+      if (text?.trim() === columnName) {
+        return this.getRow(rowText).locator('td').nth(i)
+      }
+    }
+    throw new Error(`Column "${columnName}" not found in table "${this.label}"`)
+  }
+}
+
+export class DitoForm {
+  constructor(readonly page: Page) {}
+
+  async fill(label: string, value: string) {
+    await this.page.getByLabel(label, { exact: true }).fill(value)
+  }
+
+  async select(label: string, option: string) {
+    await this.page.getByLabel(label, { exact: true }).selectOption(option)
+  }
+
+  async check(label: string) {
+    await this.page.getByLabel(label, { exact: true }).check()
+  }
+
+  async toggleSwitch(label: string) {
+    await this.page.getByLabel(label, { exact: true }).click()
+  }
+
+  async setSwitch(label: string, checked: boolean) {
+    const input = this.page.getByLabel(label, { exact: true })
+    if (checked) {
+      await input.check()
+    } else {
+      await input.uncheck()
+    }
+  }
+
+  async fillMultiselect(label: string, search: string, option?: string) {
+    await fillDitoMultiselect(this.page, this.page, label, search, option)
+  }
+
+  async clearMultiselect(label: string) {
+    // Clear button is hidden until the wrapper is hovered.
+    const wrapper = this.page
+      .locator('.dito-multiselect')
+      .filter({ has: this.page.getByRole('combobox', { name: label }) })
+    await wrapper.hover()
+    await wrapper.getByRole('button', { name: 'Clear' }).click()
+  }
+
+  async fillDate(label: string, value: string) {
+    await this.page.getByLabel(label, { exact: true }).fill(value)
+    await this.page.keyboard.press('Escape')
+  }
+
+  async clickButton(name: string) {
+    await this.page.getByRole('button', { name, exact: true }).click()
+  }
+
+  async save() {
+    const button = this.page.getByRole('button', { name: 'Save', exact: true })
+    const existingNotifications = await this.getNotificationCount()
+    await this.submitButton(button)
+    // The save response merges server data back into the form, which can
+    // (a) overwrite in-progress user state and (b) transiently re-dirty the
+    // form when nested lists come back with server-assigned ids. Re-check to
+    // outlast the re-dirty tick. A save is settled when one of the following
+    // holds:
+    //  - the form unmounted (Dito's submit defaults to `closeForm: true`, so
+    //    a successful save removes the Save button from the DOM);
+    //  - the Save button is present but disabled (form clean, no auto-close);
+    //  - a new dito-notification appeared (validation error).
+    const assertSettled = () =>
+      expect(async () => {
+        const stillVisible = await button.isVisible().catch(() => false)
+        const isClean = !stillVisible || (await button.isDisabled())
+        const notificationCount = await this.getNotificationCount()
+        expect(
+          isClean || notificationCount > existingNotifications
+        ).toBe(true)
+      }).toPass({ timeout: 15_000 })
+    await assertSettled()
+    await assertSettled()
+  }
+
+  async create() {
+    const button = this.page.getByRole('button', {
+      name: 'Create',
+      exact: true
+    })
+    await this.submitButton(button)
+  }
+
+  private async submitButton(button: Locator) {
+    // Anchor on the PATCH/POST so callers' assertions run *after* the
+    // server response.
+    const pending = this.page
+      .waitForResponse(
+        response => {
+          const method = response.request().method()
+          return (
+            (method === 'PATCH' || method === 'POST') &&
+            /\/api\//.test(response.url())
+          )
+        },
+        { timeout: 5_000 }
+      )
+      .catch(() => null)
+    // Click with a forgiving timeout: if the form is currently clean (the
+    // button is disabled because nothing's pending) the click would
+    // otherwise hang waiting for it to enable. Async events can flip the
+    // button between an isDisabled() guard and the click, so prefer
+    // click-with-timeout.
+    await button.click({ timeout: 5_000 }).catch(() => {})
+    await pending
+  }
+
+  private getNotificationCount() {
+    return this.getNotification().count()
+  }
+
+  getNotification(options: { error?: boolean; hasText?: string | RegExp } = {}) {
+    const locator = this.page.locator(
+      options.error ? '.dito-notification.error' : '.dito-notification'
+    )
+    return options.hasText ? locator.filter({ hasText: options.hasText }) : locator
+  }
+
+  async selectTab(name: string) {
+    await this.page.getByRole('tab', { name }).click()
+  }
+
+  getField(label: string) {
+    return this.page.getByLabel(label, { exact: true })
+  }
+}
+
+export class AdminListPage {
+  readonly list: DitoList
+
+  constructor(
+    readonly page: Page,
+    readonly url: string,
+    listLabel: string
+  ) {
+    this.list = new DitoList(page, listLabel)
+  }
+
+  async navigate(path = '') {
+    await this.page.goto(`${this.url}/admin${path}`)
+  }
+}
+
+export class DitoNestedList {
+  readonly container: Locator
+
+  constructor(
+    readonly page: Page,
+    readonly label: string
+  ) {
+    this.container = page.getByRole('region', { name: label })
+  }
+
+  get table() {
+    return this.container.locator(':scope > table')
+  }
+
+  get rows() {
+    return this.table.locator(':scope > tbody > tr')
+  }
+
+  async add() {
+    // Target the table's own Add button, not nested ones (like "Add Cut"
+    // inside tree-list items).
+    await this.table
+      .getByRole('rowgroup')
+      .last()
+      .getByRole('button', { name: /Create|Add/ })
+      .click()
+  }
+
+  async addType(typeName: string) {
+    await this.add()
+    await this.page.getByRole('menuitem', { name: typeName }).click()
+  }
+
+  async delete(index: number) {
+    const row = this.rows.nth(index)
+    const removeBtn = row.getByRole('button', { name: 'Remove' })
+    await row.hover()
+    await expect(removeBtn).toBeVisible()
+    await removeBtn.click()
+  }
+
+  // Dito uses SortableJS with forceFallback under webdriver, so we drive
+  // the fallback by mousedown on the drag handle, wait for the
+  // .dito-draggable__fallback/__chosen class to appear, then move past
+  // the target center to trigger the swap.
+  async dragRow(fromIndex: number, toIndex: number) {
+    const handle = (i: number) =>
+      this.rows.nth(i).locator('.dito-button[title="Drag"]')
+    const center = async (i: number) => {
+      const box = await handle(i).boundingBox()
+      if (!box)
+        throw new Error(`Missing drag handle bounding box at index ${i}`)
+      return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+    }
+    const from = await center(fromIndex)
+    await this.page.mouse.move(from.x, from.y)
+    await this.page.mouse.down()
+    await this.page
+      .locator('.dito-draggable__fallback, .dito-draggable__chosen')
+      .first()
+      .waitFor()
+    // Re-fetch the target center after the drag started — SortableJS may
+    // have shifted elements. Move past the center for a reliable swap.
+    const to = await center(toIndex)
+    const dy = to.y > from.y ? 10 : -10
+    await this.page.mouse.move(to.x, to.y + dy, { steps: 20 })
+    await this.page.mouse.up()
+  }
+}
+
+export class DitoFilterPanel {
+  private readonly region: Locator
+
+  constructor(readonly page: Page) {
+    this.region = page.getByRole('region', { name: 'Filters' })
+  }
+
+  async fillFilter(label: string, value: string) {
+    await this.region.getByLabel(label, { exact: true }).fill(value)
+  }
+}
+
+export class DitoDialog {
+  readonly locator: Locator
+
+  constructor(readonly page: Page) {
+    this.locator = page.getByRole('dialog')
+  }
+
+  getField(label: string) {
+    return this.locator.getByLabel(label, { exact: true })
+  }
+
+  getLink(name: string) {
+    return this.locator.getByRole('link', { name, exact: true })
+  }
+
+  async close() {
+    await this.locator.getByRole('button', { name: 'Close' }).click()
+  }
+}
+
+export class DitoUploadField {
+  readonly container: Locator
+
+  constructor(
+    readonly page: Page,
+    readonly name: string
+  ) {
+    this.container = page.locator(`.dito-upload:has(input#${name})`)
+  }
+
+  get rows() {
+    return this.container.locator('tbody tr')
+  }
+
+  get addButton() {
+    return this.container.locator('tfoot .dito-button--upload')
+  }
+
+  getRow(index: number) {
+    return this.rows.nth(index)
+  }
+
+  async waitUntilVisible(options?: { timeout?: number }) {
+    await expect(this.container).toBeVisible(options)
+  }
+
+  async upload(filePath: string | string[]): Promise<void> {
+    const responsePromise = this.page.waitForResponse(
+      resp => resp.url().includes('/upload/') && resp.ok()
+    )
+    const fileInput = this.container.locator('input[type="file"]').first()
+    await fileInput.setInputFiles(filePath)
+    await responsePromise
+  }
+}


### PR DESCRIPTION
- Add `tests/utils/pages.ts` with page-objects ported from lineto: `DitoList`, `DitoForm`, `AdminListPage`, `DitoNestedList`, `DitoFilterPanel`, `DitoDialog`, plus a new `DitoUploadField`. Method renames per dito's verb-prefix style (`getRow`, `getField`, `getLink`).
- Add `tests/utils/fixture-app.ts`: shared `createFixtureAppFixture` factory + relocated `createModelHelpers`. Removes boilerplate that `assets/fixtures.ts` repeats today (migration in MR 6).
- Add `tests/e2e/crud/`: scenario A — Widget CRUD round-trip exercising the new abstractions. Widens `createWidgetView` factory to accept a 4th `listOptions` arg.
