### PR TITLE
Tests: Add admin e2e scopes scenario

### DIFF
--- a/tests/e2e/crud/admin/index.spec.ts
+++ b/tests/e2e/crud/admin/index.spec.ts
@@ -1,26 +1,12 @@
 import { test, expect } from '../fixtures.js'
 import {
-  AdminListPage,
+  DitoListView,
   DitoForm
 } from '../../../utils/pages.js'
 
 test.describe('crud', () => {
-  // Warm the admin Vite bundle once per worker. The first navigation to a
-  // new admin route triggers on-demand compilation that can exceed
-  // per-test timeouts on CI cold starts.
-  test.beforeAll(async ({ browser, url }) => {
-    const page = await browser.newPage()
-    try {
-      await page.goto(`${url}/admin/widgets`, {
-        waitUntil: 'networkidle'
-      })
-    } finally {
-      await page.close()
-    }
-  })
-
   test('create, edit, delete round-trip', async ({ page, url }) => {
-    const list = new AdminListPage(page, url, 'Widget')
+    const list = new DitoListView(page, url, 'Widget')
     const form = new DitoForm(page)
 
     // Navigate. The Create button is a stable readiness signal — it's

--- a/tests/e2e/crud/fixtures.ts
+++ b/tests/e2e/crud/fixtures.ts
@@ -25,5 +25,6 @@ export const test = createFixtureAppFixture({
   controllers: {
     admin: AdminController,
     api: { Widgets }
-  }
+  },
+  warmupPath: '/admin/widgets'
 })

--- a/tests/e2e/scopes/admin/index.spec.ts
+++ b/tests/e2e/scopes/admin/index.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '../fixtures.js'
+import {
+  DitoListView,
+  DitoFilterPanel
+} from '../../../utils/pages.js'
+
+test.describe('scopes', () => {
+  test('default scope shows all widgets', async ({ page, url }) => {
+    const list = new DitoListView(page, url, 'Widget')
+    await list.navigate('/widgets')
+    await expect(
+      page.getByRole('button', { name: 'Create', exact: true })
+    ).toBeHidden()
+    // Default scope: both rows visible.
+    await expect(list.list.getRow('Alpha')).toBeVisible()
+    await expect(list.list.getRow('Beta')).toBeVisible()
+  })
+
+  test('Published scope hides unpublished rows', async ({ page, url }) => {
+    const list = new DitoListView(page, url, 'Widget')
+    await list.navigate('/widgets')
+    await list.list.selectScope('Published')
+    await expect(list.list.getRow('Alpha')).toBeVisible()
+    await expect(list.list.getRow('Beta')).toBeHidden()
+  })
+
+  test('Unpublished scope hides published rows', async ({ page, url }) => {
+    const list = new DitoListView(page, url, 'Widget')
+    await list.navigate('/widgets')
+    await list.list.selectScope('Unpublished')
+    await expect(list.list.getRow('Beta')).toBeVisible()
+    await expect(list.list.getRow('Alpha')).toBeHidden()
+  })
+
+  test('search filter narrows visible rows', async ({ page, url }) => {
+    const list = new DitoListView(page, url, 'Widget')
+    const filters = new DitoFilterPanel(page)
+    await list.navigate('/widgets')
+    await expect(list.list.getRow('Alpha')).toBeVisible()
+    await filters.fillFilter('Search', 'Alpha')
+    await expect(list.list.getRow('Alpha')).toBeVisible()
+    await expect(list.list.getRow('Beta')).toBeHidden()
+  })
+})

--- a/tests/e2e/scopes/app/index.html
+++ b/tests/e2e/scopes/app/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <style>body, html { height: 100%; margin: 0; }</style>
+  </head>
+  <body>
+    <div id="dito-admin"></div>
+    <script type="module" src="/index.ts"></script>
+  </body>
+</html>

--- a/tests/e2e/scopes/app/index.ts
+++ b/tests/e2e/scopes/app/index.ts
@@ -1,0 +1,7 @@
+import DitoAdmin from '@ditojs/admin'
+import '@ditojs/admin/style.css'
+
+new DitoAdmin('#dito-admin', {
+  dito,
+  views: import('./views/index.js')
+})

--- a/tests/e2e/scopes/app/views/index.ts
+++ b/tests/e2e/scopes/app/views/index.ts
@@ -1,0 +1,30 @@
+import type { Widget } from '../../models/Widget.js'
+import { createWidgetView } from
+  '../../../schema-components/app/views/createWidgetView.js'
+
+export const widgets = createWidgetView<Widget>(
+  'Widget',
+  'widgets',
+  {
+    name: { type: 'text', label: 'Name' },
+    published: { type: 'switch', label: 'Published' }
+  },
+  {
+    columns: {
+      name: { label: 'Name' },
+      published: { label: 'Published', render: ({ item }) => item.published ? 'Yes' : 'No' }
+    },
+    scopes: {
+      $default: { label: 'All' },
+      published: { label: 'Published' },
+      unpublished: { label: 'Unpublished' }
+    },
+    filters: {
+      search: {
+        components: {
+          search: { label: 'Search', type: 'text' }
+        }
+      }
+    }
+  }
+)

--- a/tests/e2e/scopes/fixtures.ts
+++ b/tests/e2e/scopes/fixtures.ts
@@ -1,0 +1,52 @@
+import path from 'path'
+import { AdminController, ModelController } from '@ditojs/server'
+import {
+  createFixtureAppFixture,
+  createModelHelpers
+} from '../../utils/fixture-app.js'
+import { Widget } from './models/Widget.js'
+
+export { expect } from '@playwright/test'
+export { createModelHelpers, Widget }
+
+class Widgets extends ModelController {
+  override modelClass = Widget
+  collection = {
+    allow: ['get', 'post'] as const
+  }
+  member = {
+    allow: ['get', 'patch', 'delete'] as const
+  }
+}
+
+export const test = createFixtureAppFixture({
+  appRoot: path.resolve(import.meta.dirname, 'app'),
+  models: { Widget },
+  controllers: {
+    admin: AdminController,
+    api: { Widgets }
+  },
+  warmupPath: '/admin/widgets'
+}).extend<{ seedWidgets: void }>({
+  // Auto-runs before every test in this scenario. Tests share one PGlite
+  // DB per worker (Playwright runs in-file tests sequentially), so reset
+  // before seeding to keep tests independent.
+  //
+  // The `url: _url` parameter looks unused, but it isn't — Playwright
+  // fixtures only initialize on request, and requesting `url` here is
+  // what triggers the worker-fixture chain that boots the embedded app
+  // and binds `Widget` to the in-process knex. Without this dependency,
+  // `Widget.query()` below would throw "no database connection". The `_`
+  // prefix tells the linter the value is intentionally unused.
+  seedWidgets: [
+    async ({ url: _url }, use) => {
+      await Widget.query().delete()
+      await Widget.query().insert([
+        { name: 'Alpha', published: true },
+        { name: 'Beta', published: false }
+      ])
+      await use()
+    },
+    { auto: true }
+  ]
+})

--- a/tests/e2e/scopes/models/Widget.ts
+++ b/tests/e2e/scopes/models/Widget.ts
@@ -1,0 +1,28 @@
+import type { ModelProperties } from '@ditojs/server'
+import { Model } from '@ditojs/server'
+import type { QueryBuilder } from 'objection'
+
+export interface Widget {
+  id: number
+  name: string
+  published: boolean
+}
+
+export class Widget extends Model {
+  static override properties: ModelProperties = {
+    name: { type: 'string', required: true },
+    published: { type: 'boolean', default: false }
+  }
+
+  static override scopes = {
+    published: (query: QueryBuilder<Widget>) => query.where('published', true),
+    unpublished: (query: QueryBuilder<Widget>) =>
+      query.where('published', false)
+  }
+
+  static override filters = {
+    search(query: QueryBuilder<Widget>, search: string) {
+      query.whereILike('name', `%${search}%`)
+    }
+  }
+}

--- a/tests/utils/fixture-app.ts
+++ b/tests/utils/fixture-app.ts
@@ -17,6 +17,10 @@ export interface FixtureAppOptions {
   controllers: Record<string, unknown>
   /** Optional extra config merged into `createTestApp`'s `config`. */
   config?: Record<string, unknown>
+  /** If set, the worker fixture warms the admin Vite bundle by visiting
+   * `${url}${warmupPath}` once after the app starts. Avoids first-test
+   * cold-compile timeouts in CI. */
+  warmupPath?: string
 }
 
 /**
@@ -27,7 +31,7 @@ export interface FixtureAppOptions {
 export function createFixtureAppFixture(opts: FixtureAppOptions) {
   return base.extend<{ url: string }, { workerUrl: string }>({
     workerUrl: [
-      async ({}, use) => {
+      async ({ browser }, use) => {
         const app = createTestApp({
           models: opts.models,
           controllers: opts.controllers,
@@ -43,6 +47,20 @@ export function createFixtureAppFixture(opts: FixtureAppOptions) {
         await app.start()
         const url = getAppUrl(app)
         await waitForUrl(`${url}/admin/`)
+
+        if (opts.warmupPath) {
+          // Warm the admin Vite bundle once per worker so the first
+          // per-test navigation doesn't burn a per-test timeout on cold
+          // compile.
+          const page = await browser.newPage()
+          try {
+            await page.goto(`${url}${opts.warmupPath}`, {
+              waitUntil: 'networkidle'
+            })
+          } finally {
+            await page.close()
+          }
+        }
 
         await use(url)
 

--- a/tests/utils/pages.ts
+++ b/tests/utils/pages.ts
@@ -223,7 +223,7 @@ export class DitoForm {
   }
 }
 
-export class AdminListPage {
+export class DitoListView {
   readonly list: DitoList
 
   constructor(
@@ -317,7 +317,16 @@ export class DitoFilterPanel {
   }
 
   async fillFilter(label: string, value: string) {
-    await this.region.getByLabel(label, { exact: true }).fill(value)
+    // Filters use a `components: { ... }` wrapping schema, so the rendered
+    // `<label for="…">` points at the outer wrapper div, not the input.
+    // Match by role + accessible name (resolves through placeholder/title)
+    // for a stable target.
+    await this.region
+      .getByRole('textbox', { name: label, exact: true })
+      .fill(value)
+    // Filter panel commits queries via the explicit Filter button — typing
+    // alone doesn't refresh the list.
+    await this.region.getByRole('button', { name: 'Filter', exact: true }).click()
   }
 }
 


### PR DESCRIPTION
- Add `tests/e2e/scopes/`: Widget model with `published` flag, scopes (`published`/`unpublished`) and a `search` filter; admin list view with scope tabs and a search filter panel.
- Spec exercises `DitoList.selectScope` and `DitoFilterPanel.fillFilter` from MR 1's page-objects.
- Fix `DitoFilterPanel.fillFilter` to target the input via role+name (the wrapped filter schema makes \`<label for=\"...\">\` point at the wrapper div) and commit via the explicit Filter button.