### PR TITLE
Tests: Add admin e2e multiselect scenario

### DIFF
--- a/tests/e2e/multiselect/admin/index.spec.ts
+++ b/tests/e2e/multiselect/admin/index.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect, Widget } from '../fixtures.js'
+import {
+  DitoListView,
+  DitoForm
+} from '../../../utils/pages.js'
+
+test.describe('multiselect', () => {
+  test('select tags, save, reload — value persists; clear, save, reload — empty', async ({
+    page,
+    url
+  }) => {
+    // Seed a widget tied to no tags initially.
+    const widget = await Widget.query().insert({ name: 'Widget A' })
+
+    const list = new DitoListView(page, url, 'Widget')
+    const form = new DitoForm(page)
+
+    await list.navigate('/widgets')
+    await list.list.edit('Widget A')
+    await form.fillMultiselect('Tags', 'tag-1')
+    await form.fillMultiselect('Tags', 'tag-2')
+    await form.save()
+
+    // Reload from main list.
+    await list.navigate('/widgets')
+    await list.list.edit('Widget A')
+
+    // Tag chips should be visible. Each chip carries the tag's name; the
+    // multiselect renders selected items as chips inside the combobox.
+    const tagsCombobox = page.getByRole('combobox', { name: 'Tags' })
+    await expect(tagsCombobox).toContainText('tag-1')
+    await expect(tagsCombobox).toContainText('tag-2')
+
+    // Re-fetch from DB and confirm the join-table relation persisted.
+    const persisted = await Widget.query().findById(widget.$id() as number).withGraphFetched('tags')
+    const persistedNames = (persisted?.tags ?? []).map(t => t.name).sort()
+    expect(persistedNames).toEqual(['tag-1', 'tag-2'])
+
+    // Clear all tags.
+    await form.clearMultiselect('Tags')
+    await form.save()
+
+    // Reload, confirm empty.
+    await list.navigate('/widgets')
+    await list.list.edit('Widget A')
+    await expect(tagsCombobox).not.toContainText('tag-1')
+    await expect(tagsCombobox).not.toContainText('tag-2')
+
+    const cleared = await Widget.query().findById(widget.$id() as number).withGraphFetched('tags')
+    expect(cleared?.tags ?? []).toHaveLength(0)
+  })
+})

--- a/tests/e2e/multiselect/app/index.html
+++ b/tests/e2e/multiselect/app/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <style>body, html { height: 100%; margin: 0; }</style>
+  </head>
+  <body>
+    <div id="dito-admin"></div>
+    <script type="module" src="/index.ts"></script>
+  </body>
+</html>

--- a/tests/e2e/multiselect/app/index.ts
+++ b/tests/e2e/multiselect/app/index.ts
@@ -1,0 +1,7 @@
+import DitoAdmin from '@ditojs/admin'
+import '@ditojs/admin/style.css'
+
+new DitoAdmin('#dito-admin', {
+  dito,
+  views: import('./views/index.js')
+})

--- a/tests/e2e/multiselect/app/views/index.ts
+++ b/tests/e2e/multiselect/app/views/index.ts
@@ -1,0 +1,29 @@
+import type { Tag } from '../../models/Tag.js'
+import type { Widget } from '../../models/Widget.js'
+import { createWidgetView } from
+  '../../../schema-components/app/views/createWidgetView.js'
+
+export const widgets = createWidgetView<Widget>(
+  'Widget',
+  'widgets',
+  {
+    name: { type: 'text', label: 'Name' },
+    tags: {
+      type: 'multiselect',
+      label: 'Tags',
+      multiple: true,
+      relate: true,
+      clearable: true,
+      options: {
+        data: ({ request }: { request: (opts: { url: string }) => Promise<Tag[]> }) =>
+          request({ url: 'tags' }),
+        label: 'name',
+        value: 'id'
+      }
+    }
+  },
+  {
+    creatable: true,
+    columns: { name: { label: 'Name' } }
+  }
+)

--- a/tests/e2e/multiselect/fixtures.ts
+++ b/tests/e2e/multiselect/fixtures.ts
@@ -1,0 +1,81 @@
+import path from 'path'
+import { AdminController, ModelController } from '@ditojs/server'
+import {
+  createFixtureAppFixture,
+  createModelHelpers
+} from '../../utils/fixture-app.js'
+import { Tag } from './models/Tag.js'
+import { Widget } from './models/Widget.js'
+
+export { expect } from '@playwright/test'
+export { createModelHelpers, Tag, Widget }
+
+class Widgets extends ModelController {
+  override modelClass = Widget
+  // `^withTags` forces the model's `withTags` scope on every query so GETs
+  // re-hydrate the relation. `graph = true` switches PATCH/POST to the
+  // graph variants (patchDitoGraphAndFetch) so `tags: [...]` in the body
+  // actually writes through to the WidgetTag join table.
+  override scope = ['^withTags']
+  override graph = true
+  collection = {
+    allow: ['get', 'post'] as const
+  }
+  member = {
+    allow: ['get', 'patch', 'delete'] as const
+  }
+}
+
+class Tags extends ModelController {
+  override modelClass = Tag
+  collection = {
+    allow: ['get', 'post'] as const
+  }
+  member = {
+    allow: ['get', 'patch', 'delete'] as const
+  }
+}
+
+export const test = createFixtureAppFixture({
+  appRoot: path.resolve(import.meta.dirname, 'app'),
+  models: { Widget, Tag },
+  controllers: {
+    admin: AdminController,
+    api: { Widgets, Tags }
+  },
+  setupHook: async app => {
+    // Dito's `buildThrough` auto-derives the join table as
+    // `${fromName}${toName}` (declaration order, not alphabetical) —
+    // since the relation is `Widget.tags`, the table is `WidgetTag`.
+    await app.knex.schema.createTable('WidgetTag', table => {
+      table.increments('id').primary()
+      table.integer('widgetId').unsigned().references('id').inTable('Widget')
+      table.integer('tagId').unsigned().references('id').inTable('Tag')
+    })
+  },
+  warmupPath: '/admin/widgets'
+}).extend<{ seedTags: void }>({
+  // Auto-runs before every test. Tests share one PGlite DB per worker
+  // (Playwright runs in-file tests sequentially), so reset before seeding.
+  //
+  // The `url: _url` parameter looks unused, but it isn't — Playwright
+  // fixtures only initialize on request, and requesting `url` here is what
+  // triggers the worker fixture chain that boots the embedded app and
+  // binds models to in-process knex. Without it, `Widget.query()` and
+  // `Tag.query()` below would throw "no database connection".
+  seedTags: [
+    async ({ url: _url }, use) => {
+      // Clear join table first to avoid FK violations.
+      await Widget.knex().table('WidgetTag').delete()
+      await Widget.query().delete()
+      await Tag.query().delete()
+      await Tag.query().insert([
+        { name: 'tag-1' },
+        { name: 'tag-2' },
+        { name: 'tag-3' }
+      ])
+      await use()
+    },
+    { auto: true }
+  ]
+})

--- a/tests/e2e/multiselect/models/Tag.ts
+++ b/tests/e2e/multiselect/models/Tag.ts
@@ -1,0 +1,13 @@
+import type { ModelProperties } from '@ditojs/server'
+import { Model } from '@ditojs/server'
+
+export interface Tag {
+  id: number
+  name: string
+}
+
+export class Tag extends Model {
+  static override properties: ModelProperties = {
+    name: { type: 'string', required: true }
+  }
+}

--- a/tests/e2e/multiselect/models/Widget.ts
+++ b/tests/e2e/multiselect/models/Widget.ts
@@ -1,0 +1,32 @@
+import type { ModelProperties, RelationMappings } from '@ditojs/server'
+import { Model } from '@ditojs/server'
+import type { QueryBuilder } from 'objection'
+import { Tag } from './Tag.js'
+
+export interface Widget {
+  id: number
+  name: string
+  tags?: Tag[]
+}
+
+export class Widget extends Model {
+  static override properties: ModelProperties = {
+    name: { type: 'string', required: true }
+  }
+
+  static override relations: RelationMappings = {
+    tags: {
+      relation: 'manyToMany',
+      from: 'Widget.id',
+      to: 'Tag.id'
+    }
+  }
+
+  static override scopes = {
+    // Eager-load tags so the admin form re-hydrates the multiselect after
+    // reload. Applied as `^withTags` on the Widgets controller below so
+    // every query goes through this scope.
+    withTags: (query: QueryBuilder<Widget>) =>
+      query.withGraphFetched('tags')
+  }
+}

--- a/tests/utils/fixture-app.ts
+++ b/tests/utils/fixture-app.ts
@@ -21,6 +21,10 @@ export interface FixtureAppOptions {
    * `${url}${warmupPath}` once after the app starts. Avoids first-test
    * cold-compile timeouts in CI. */
   warmupPath?: string
+  /** If set, runs after `createTestDatabase(app)` and before `app.start()`.
+   * Use this to create extra schema (e.g. join tables for many-to-many
+   * relations that `createTestDatabase` doesn't auto-derive). */
+  setupHook?: (app: ReturnType<typeof createTestApp>) => Promise<void>
 }
 
 /**
@@ -44,6 +48,9 @@ export function createFixtureAppFixture(opts: FixtureAppOptions) {
 
         stubSession(app)
         await createTestDatabase(app)
+        if (opts.setupHook) {
+          await opts.setupHook(app)
+        }
         await app.start()
         const url = getAppUrl(app)
         await waitForUrl(`${url}/admin/`)

--- a/tests/utils/pages.ts
+++ b/tests/utils/pages.ts
@@ -11,7 +11,14 @@ export async function fillDitoMultiselect(
 ) {
   const combobox = scope.getByRole('combobox', { name: label })
   await combobox.click()
-  await combobox.locator('input').fill(search)
+  // Multiselects with `searchable: true` expose a text input inside the
+  // combobox — type to narrow the list. The dito default is
+  // `searchable: false`: clicking already shows all options, no input
+  // exists, so skip the type step.
+  const input = combobox.locator('input')
+  if (await input.count()) {
+    await input.fill(search)
+  }
   // Exact so e.g. "Cyrillic" doesn't also match "Latin & Cyrillic".
   await page
     .getByRole('option', { name: option ?? search, exact: true })


### PR DESCRIPTION
- Add `tests/e2e/multiselect/`: Tag + Widget models linked many-to-many; admin form with a multiselect bound to the relation via `relate: true`, `clearable: true`, and an `options.data` fetch from the Tags REST resource.
- Spec seeds three tags, edits the widget, picks two via `DitoForm.fillMultiselect`, saves, reloads, asserts persistence (UI chips + DB join table). Then `clearMultiselect`, save, reload, assert empty.
- Add `setupHook` option to `createFixtureAppFixture` so scenarios can create extra schema (here: the auto-derived `WidgetTag` join table).
- Make `fillDitoMultiselect` handle non-searchable comboboxes (skip the `.fill()` step when no input element exists in the combobox).