### PR TITLE
Tests: Add admin e2e validation scenario

### DIFF
--- a/tests/e2e/validation/admin/index.spec.ts
+++ b/tests/e2e/validation/admin/index.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '../fixtures.js'
+import {
+  DitoListView,
+  DitoForm
+} from '../../../utils/pages.js'
+
+test.describe('validation', () => {
+  test('invalid submit surfaces an error notification', async ({
+    page,
+    url
+  }) => {
+    const list = new DitoListView(page, url, 'Widget')
+    const form = new DitoForm(page)
+
+    await list.navigate('/widgets')
+    await list.list.create()
+    // Submit without filling Name (required + minLength 3). Server returns
+    // 400; admin renders an error notification with generic text. Per-field
+    // detail appears in field tooltips (not asserted here — would require a
+    // dedicated page-object helper).
+    await form.create()
+
+    await expect(form.getNotification({ error: true })).toContainText(
+      /validation|correct/i
+    )
+  })
+
+  test('valid data creates a row', async ({ page, url }) => {
+    const list = new DitoListView(page, url, 'Widget')
+    const form = new DitoForm(page)
+
+    await list.navigate('/widgets')
+    await list.list.create()
+    await form.fill('Name', 'Valid Name')
+    await form.fill('Email', 'valid@example.com')
+    await form.create()
+
+    await expect(list.list.getRow('Valid Name')).toBeVisible()
+  })
+})

--- a/tests/e2e/validation/app/index.html
+++ b/tests/e2e/validation/app/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <style>body, html { height: 100%; margin: 0; }</style>
+  </head>
+  <body>
+    <div id="dito-admin"></div>
+    <script type="module" src="/index.ts"></script>
+  </body>
+</html>

--- a/tests/e2e/validation/app/index.ts
+++ b/tests/e2e/validation/app/index.ts
@@ -1,0 +1,7 @@
+import DitoAdmin from '@ditojs/admin'
+import '@ditojs/admin/style.css'
+
+new DitoAdmin('#dito-admin', {
+  dito,
+  views: import('./views/index.js')
+})

--- a/tests/e2e/validation/app/views/index.ts
+++ b/tests/e2e/validation/app/views/index.ts
@@ -1,0 +1,16 @@
+import type { Widget } from '../../models/Widget.js'
+import { createWidgetView } from
+  '../../../schema-components/app/views/createWidgetView.js'
+
+export const widgets = createWidgetView<Widget>(
+  'Widget',
+  'widgets',
+  {
+    name: { type: 'text', label: 'Name' },
+    email: { type: 'email', label: 'Email' }
+  },
+  {
+    creatable: true,
+    columns: { name: { label: 'Name' } }
+  }
+)

--- a/tests/e2e/validation/fixtures.ts
+++ b/tests/e2e/validation/fixtures.ts
@@ -1,0 +1,47 @@
+import path from 'path'
+import { AdminController, ModelController } from '@ditojs/server'
+import {
+  createFixtureAppFixture,
+  createModelHelpers
+} from '../../utils/fixture-app.js'
+import { Widget } from './models/Widget.js'
+
+export { expect } from '@playwright/test'
+export { createModelHelpers, Widget }
+
+class Widgets extends ModelController {
+  override modelClass = Widget
+  collection = {
+    allow: ['get', 'post'] as const
+  }
+  member = {
+    allow: ['get', 'patch', 'delete'] as const
+  }
+}
+
+export const test = createFixtureAppFixture({
+  appRoot: path.resolve(import.meta.dirname, 'app'),
+  models: { Widget },
+  controllers: {
+    admin: AdminController,
+    api: { Widgets }
+  },
+  warmupPath: '/admin/widgets'
+}).extend<{ resetWidgets: void }>({
+  // Auto-runs before every test in this scenario. Tests share one PGlite
+  // DB per worker (Playwright runs in-file tests sequentially), so reset
+  // between tests so a row created by one test doesn't leak into another.
+  //
+  // The `url: _url` parameter looks unused but isn't — Playwright fixtures
+  // only initialize on request, and naming `url` here triggers the worker
+  // fixture chain that boots the embedded app and binds Widget to the
+  // in-process knex. Without it, `Widget.query()` below would throw "no
+  // database connection". The `_` prefix tells the linter it's intentional.
+  resetWidgets: [
+    async ({ url: _url }, use) => {
+      await Widget.query().delete()
+      await use()
+    },
+    { auto: true }
+  ]
+})

--- a/tests/e2e/validation/models/Widget.ts
+++ b/tests/e2e/validation/models/Widget.ts
@@ -1,0 +1,23 @@
+import type { ModelProperties } from '@ditojs/server'
+import { Model } from '@ditojs/server'
+
+export interface Widget {
+  id: number
+  name: string
+  email: string | null
+}
+
+export class Widget extends Model {
+  static override properties: ModelProperties = {
+    name: {
+      type: 'string',
+      required: true,
+      minLength: 3
+    },
+    email: {
+      type: 'string',
+      format: 'email',
+      nullable: true
+    }
+  }
+}


### PR DESCRIPTION
- Add `tests/e2e/validation/`: Widget model with `required` + `minLength: 3` on `name` and `format: 'email'` on `email`; admin form binds both as text/email inputs.
- Spec submits empty form (asserts the generic `dito-notification.error` body matches `/validation|correct/i`), then submits valid data (asserts row created).
- Email format isn't currently enforced server-side (Dito's default Ajv config doesn't register the `email` format); the field is kept on the model for the valid-data round-trip but format-violation testing is deferred until format registration is set up.