### PR TITLE
Tests: Add admin e2e nested-list scenario

### DIFF
--- a/tests/e2e/nested-list/admin/index.spec.ts
+++ b/tests/e2e/nested-list/admin/index.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect, Widget } from '../fixtures.js'
+import {
+  DitoListView,
+  DitoForm,
+  DitoNestedList
+} from '../../../utils/pages.js'
+
+test.describe('nested-list', () => {
+  test('add items, save, reload, delete one, reload', async ({
+    page,
+    url
+  }) => {
+    // Seed a widget with no items initially.
+    const widget = await Widget.query().insert({ name: 'Widget A' })
+
+    const list = new DitoListView(page, url, 'Widget')
+    const form = new DitoForm(page)
+    const items = new DitoNestedList(page, 'Items')
+
+    await list.navigate('/widgets')
+    await list.list.edit('Widget A')
+
+    // Add two items via the nested list. Each Add click appends a new
+    // row whose inline form contains a Label field. Fill by row index
+    // to disambiguate from the previously-added row.
+    await items.add()
+    await items.rows
+      .nth(0)
+      .getByLabel('Label', { exact: true })
+      .fill('first')
+    await items.add()
+    await items.rows
+      .nth(1)
+      .getByLabel('Label', { exact: true })
+      .fill('second')
+
+    await form.save()
+
+    // Reload via the list and confirm the items rehydrated with the
+    // typed labels.
+    await list.navigate('/widgets')
+    await list.list.edit('Widget A')
+    await expect(items.rows).toHaveCount(2)
+    await expect(items.rows.nth(0).getByLabel('Label')).toHaveValue('first')
+    await expect(items.rows.nth(1).getByLabel('Label')).toHaveValue('second')
+
+    // Confirm DB state matches.
+    const persisted = await Widget.query()
+      .findById(widget.$id() as number)
+      .withGraphFetched('items')
+    const persistedLabels = (persisted?.items ?? [])
+      .map(i => i.label)
+      .sort()
+    expect(persistedLabels).toEqual(['first', 'second'])
+
+    // Delete the first item, save, reload, assert one remains with the
+    // surviving label.
+    await items.delete(0)
+    await form.save()
+    await list.navigate('/widgets')
+    await list.list.edit('Widget A')
+    await expect(items.rows).toHaveCount(1)
+    await expect(items.rows.nth(0).getByLabel('Label')).toHaveValue('second')
+
+    const remaining = await Widget.query()
+      .findById(widget.$id() as number)
+      .withGraphFetched('items')
+    const remainingLabels = (remaining?.items ?? []).map(i => i.label)
+    expect(remainingLabels).toEqual(['second'])
+  })
+})

--- a/tests/e2e/nested-list/app/index.html
+++ b/tests/e2e/nested-list/app/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <style>body, html { height: 100%; margin: 0; }</style>
+  </head>
+  <body>
+    <div id="dito-admin"></div>
+    <script type="module" src="/index.ts"></script>
+  </body>
+</html>

--- a/tests/e2e/nested-list/app/index.ts
+++ b/tests/e2e/nested-list/app/index.ts
@@ -1,0 +1,7 @@
+import DitoAdmin from '@ditojs/admin'
+import '@ditojs/admin/style.css'
+
+new DitoAdmin('#dito-admin', {
+  dito,
+  views: import('./views/index.js')
+})

--- a/tests/e2e/nested-list/app/views/index.ts
+++ b/tests/e2e/nested-list/app/views/index.ts
@@ -1,0 +1,28 @@
+import type { Widget } from '../../models/Widget.js'
+import { createWidgetView } from
+  '../../../schema-components/app/views/createWidgetView.js'
+
+export const widgets = createWidgetView<Widget>(
+  'Widget',
+  'widgets',
+  {
+    name: { type: 'text', label: 'Name' },
+    items: {
+      type: 'list',
+      label: 'Items',
+      inlined: true,
+      creatable: true,
+      deletable: true,
+      form: {
+        type: 'form',
+        components: {
+          label: { type: 'text', label: 'Label' }
+        }
+      }
+    }
+  },
+  {
+    creatable: true,
+    columns: { name: { label: 'Name' } }
+  }
+)

--- a/tests/e2e/nested-list/fixtures.ts
+++ b/tests/e2e/nested-list/fixtures.ts
@@ -1,0 +1,66 @@
+import path from 'path'
+import { AdminController, ModelController } from '@ditojs/server'
+import {
+  createFixtureAppFixture,
+  createModelHelpers
+} from '../../utils/fixture-app.js'
+import { Item } from './models/Item.js'
+import { Widget } from './models/Widget.js'
+
+export { expect } from '@playwright/test'
+export { createModelHelpers, Item, Widget }
+
+class Widgets extends ModelController {
+  override modelClass = Widget
+  // `^withItems` forces the model's `withItems` scope on every query so
+  // GET /api/widgets/:id re-hydrates the items relation. `graph = true`
+  // switches PATCH/POST to the graph variants so `items: [...]` in the
+  // body actually inserts/updates Item rows (combined with `owner: true`
+  // on the relation).
+  override scope = ['^withItems']
+  override graph = true
+  collection = {
+    allow: ['get', 'post'] as const
+  }
+  member = {
+    allow: ['get', 'patch', 'delete'] as const
+  }
+}
+
+class Items extends ModelController {
+  override modelClass = Item
+  collection = {
+    allow: ['get', 'post'] as const
+  }
+  member = {
+    allow: ['get', 'patch', 'delete'] as const
+  }
+}
+
+export const test = createFixtureAppFixture({
+  appRoot: path.resolve(import.meta.dirname, 'app'),
+  models: { Widget, Item },
+  controllers: {
+    admin: AdminController,
+    api: { Widgets, Items }
+  },
+  warmupPath: '/admin/widgets'
+}).extend<{ resetState: void }>({
+  // Auto-runs before every test. Tests share one PGlite DB per worker
+  // (Playwright runs in-file tests sequentially), so reset before each.
+  // Order: clear Item first (FK to Widget), then Widget.
+  //
+  // The `url: _url` parameter looks unused but isn't — Playwright
+  // fixtures only initialize on request, and naming `url` here triggers
+  // the worker fixture chain that boots the embedded app and binds
+  // models to in-process knex. The `_` prefix tells the linter it's
+  // intentional.
+  resetState: [
+    async ({ url: _url }, use) => {
+      await Item.query().delete()
+      await Widget.query().delete()
+      await use()
+    },
+    { auto: true }
+  ]
+})

--- a/tests/e2e/nested-list/models/Item.ts
+++ b/tests/e2e/nested-list/models/Item.ts
@@ -1,0 +1,18 @@
+import type { ModelProperties } from '@ditojs/server'
+import { Model } from '@ditojs/server'
+
+export interface Item {
+  id: number
+  widgetId: number
+  label: string
+}
+
+export class Item extends Model {
+  static override properties: ModelProperties = {
+    // `widgetId` is nullable in the schema because Dito's graph save sets
+    // it on inserted children from the parent relation — the request body
+    // doesn't carry it.
+    widgetId: { type: 'integer', index: true, nullable: true },
+    label: { type: 'string', required: true }
+  }
+}

--- a/tests/e2e/nested-list/models/Widget.ts
+++ b/tests/e2e/nested-list/models/Widget.ts
@@ -1,0 +1,37 @@
+import type { ModelProperties, RelationMappings } from '@ditojs/server'
+import { Model } from '@ditojs/server'
+import type { QueryBuilder } from 'objection'
+import { Item } from './Item.js'
+
+export interface Widget {
+  id: number
+  name: string
+  items?: Item[]
+}
+
+export class Widget extends Model {
+  static override properties: ModelProperties = {
+    name: { type: 'string', required: true }
+  }
+
+  static override relations: RelationMappings = {
+    items: {
+      relation: 'hasMany',
+      from: 'Widget.id',
+      to: 'Item.widgetId',
+      // `owner: true` tells Dito the parent fully owns the children, so a
+      // graph save inserts/updates/deletes child rows with their data
+      // (label, etc.) rather than treating incoming items as relate-by-id
+      // references.
+      owner: true
+    }
+  }
+
+  static override scopes = {
+    // Eager-load items so the admin form re-hydrates the nested list on
+    // edit reload. Applied as `^withItems` on the Widgets controller in
+    // fixtures.ts so every query goes through this scope.
+    withItems: (query: QueryBuilder<Widget>) =>
+      query.withGraphFetched('items')
+  }
+}

--- a/tests/utils/pages.ts
+++ b/tests/utils/pages.ts
@@ -284,6 +284,10 @@ export class DitoNestedList {
     const removeBtn = row.getByRole('button', { name: 'Remove' })
     await row.hover()
     await expect(removeBtn).toBeVisible()
+    // Dito's nested list confirms removals via window.confirm. Playwright
+    // auto-dismisses dialogs by default — register a one-shot accept
+    // handler before triggering the click.
+    this.page.once('dialog', dialog => dialog.accept())
     await removeBtn.click()
   }
 


### PR DESCRIPTION
- Add `tests/e2e/nested-list/`: Widget + Item models linked via `hasMany` with `owner: true` so a graph save inserts/updates/deletes child rows with their data (not just relate-by-id refs); admin form has an inline nested list with a `label` text component per item.
- Spec adds two items via `DitoNestedList.add()` + per-row `getByLabel('Label')`, saves, reloads, asserts UI + DB persistence (`withGraphFetched('items')`); deletes one, saves, reloads, asserts the survivor.
- Fix `DitoNestedList.delete` to accept the `window.confirm` removal dialog (Playwright auto-dismisses by default).