### PR TITLE
Tests: Migrate assets/ to shared page-objects + lifecycle primitives

### DIFF
--- a/tests/e2e/assets/admin/delete.ts
+++ b/tests/e2e/assets/admin/delete.ts
@@ -1,8 +1,9 @@
 import path from 'path'
 import {
-  test, expect, createModelHelpers,
-  uploadFile, fixturesDir
+  test, expect, fixturesDir
 } from '../fixtures.js'
+import { createModelHelpers } from '../../../utils/fixture-app.js'
+import { DitoUploadField } from '../../../utils/pages.js'
 import { AssetWidget } from '../models/AssetWidget.js'
 
 const { seed, saveAndFetch } = createModelHelpers(
@@ -17,30 +18,21 @@ test.describe('delete', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      const upload = page.locator(
-        '.dito-upload:has(input#files)'
-      )
-      await expect(upload).toBeVisible(
-        { timeout: 15_000 }
-      )
+      const upload = new DitoUploadField(page, 'files')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.png')
       )
-      await expect(
-        upload.locator('tbody tr')
-      ).toHaveCount(1)
+      await expect(upload.rows).toHaveCount(1)
 
       // Accept the confirm dialog
       page.on('dialog', dialog => dialog.accept())
-      await upload.locator(
+      await upload.container.locator(
         '.dito-button--delete'
       ).first().click()
 
-      await expect(
-        upload.locator('tbody tr')
-      ).toHaveCount(0)
+      await expect(upload.rows).toHaveCount(0)
     }
   )
 
@@ -51,15 +43,10 @@ test.describe('delete', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      const upload = page.locator(
-        '.dito-upload:has(input#files)'
-      )
-      await expect(upload).toBeVisible(
-        { timeout: 15_000 }
-      )
+      const upload = new DitoUploadField(page, 'files')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.png')
       )
 
@@ -67,14 +54,12 @@ test.describe('delete', () => {
       page.once('dialog', dialog =>
         dialog.dismiss()
       )
-      await upload.locator(
+      await upload.container.locator(
         '.dito-button--delete'
       ).first().click()
 
       // File should still be there
-      await expect(
-        upload.locator('tbody tr')
-      ).toHaveCount(1)
+      await expect(upload.rows).toHaveCount(1)
     }
   )
 
@@ -85,16 +70,11 @@ test.describe('delete', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      const upload = page.locator(
-        '.dito-upload:has(input#files)'
-      )
-      await expect(upload).toBeVisible(
-        { timeout: 15_000 }
-      )
+      const upload = new DitoUploadField(page, 'files')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
       // Upload and save first
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.png')
       )
       await saveAndFetch(page, widgetId)
@@ -103,18 +83,14 @@ test.describe('delete', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      await expect(
-        upload.locator('tbody tr')
-      ).toHaveCount(1)
+      await expect(upload.rows).toHaveCount(1)
 
       page.on('dialog', dialog => dialog.accept())
-      await upload.locator(
+      await upload.container.locator(
         '.dito-button--delete'
       ).first().click()
 
-      await expect(
-        upload.locator('tbody tr')
-      ).toHaveCount(0)
+      await expect(upload.rows).toHaveCount(0)
 
       const widget = await saveAndFetch(
         page, widgetId
@@ -131,20 +107,15 @@ test.describe('delete', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      const upload = page.locator(
-        '.dito-upload:has(input#files)'
-      )
-      await expect(upload).toBeVisible(
-        { timeout: 15_000 }
-      )
+      const upload = new DitoUploadField(page, 'files')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.png')
       )
 
       page.on('dialog', dialog => dialog.accept())
-      await upload.locator(
+      await upload.container.locator(
         '.dito-button--delete'
       ).first().click()
 
@@ -168,16 +139,11 @@ test.describe('delete', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      const upload = page.locator(
-        '.dito-upload:has(input#files)'
-      )
-      await expect(upload).toBeVisible(
-        { timeout: 15_000 }
-      )
+      const upload = new DitoUploadField(page, 'files')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
       // Upload first file and save
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.png')
       )
       const widget1 = await saveAndFetch(
@@ -189,21 +155,16 @@ test.describe('delete', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      await expect(
-        upload.locator('tbody tr')
-      ).toHaveCount(1)
+      await expect(upload.rows).toHaveCount(1)
 
       page.on('dialog', dialog => dialog.accept())
-      await upload.locator(
+      await upload.container.locator(
         '.dito-button--delete'
       ).first().click()
 
-      await expect(
-        upload.locator('tbody tr')
-      ).toHaveCount(0)
+      await expect(upload.rows).toHaveCount(0)
 
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'small.png')
       )
 

--- a/tests/e2e/assets/admin/drag-reorder.ts
+++ b/tests/e2e/assets/admin/drag-reorder.ts
@@ -1,8 +1,9 @@
 import path from 'path'
 import {
-  test, expect, createModelHelpers,
-  uploadFile, fixturesDir
+  test, expect, fixturesDir
 } from '../fixtures.js'
+import { createModelHelpers } from '../../../utils/fixture-app.js'
+import { DitoUploadField } from '../../../utils/pages.js'
 import { AssetWidget } from '../models/AssetWidget.js'
 
 const { seed, saveAndFetch } = createModelHelpers(
@@ -17,29 +18,23 @@ test.describe('drag reorder', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      const upload = page.locator(
-        '.dito-upload:has(input#files)'
-      )
-      await expect(upload).toBeVisible(
-        { timeout: 15_000 }
-      )
+      const upload = new DitoUploadField(page, 'files')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
       // Upload one file — no drag handle
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.png')
       )
       await expect(
-        upload.locator('.dito-button--drag')
+        upload.container.locator('.dito-button--drag')
       ).toHaveCount(0)
 
       // Upload second file — drag handles appear
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.jpg')
       )
       await expect(
-        upload.locator('.dito-button--drag')
+        upload.container.locator('.dito-button--drag')
       ).toHaveCount(2)
     }
   )
@@ -51,28 +46,21 @@ test.describe('drag reorder', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      const upload = page.locator(
-        '.dito-upload:has(input#files)'
-      )
-      await expect(upload).toBeVisible(
-        { timeout: 15_000 }
-      )
+      const upload = new DitoUploadField(page, 'files')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.png')
       )
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.jpg')
       )
 
       // Verify initial order
-      const rows = upload.locator('tbody tr')
-      await expect(rows.nth(0)).toContainText(
+      await expect(upload.getRow(0)).toContainText(
         'tiny.png'
       )
-      await expect(rows.nth(1)).toContainText(
+      await expect(upload.getRow(1)).toContainText(
         'tiny.jpg'
       )
 
@@ -113,10 +101,10 @@ test.describe('drag reorder', () => {
       })
 
       // Verify new order in DOM
-      await expect(rows.nth(0)).toContainText(
+      await expect(upload.getRow(0)).toContainText(
         'tiny.jpg'
       )
-      await expect(rows.nth(1)).toContainText(
+      await expect(upload.getRow(1)).toContainText(
         'tiny.png'
       )
 

--- a/tests/e2e/assets/admin/single-mode.ts
+++ b/tests/e2e/assets/admin/single-mode.ts
@@ -1,11 +1,12 @@
 import path from 'path'
 import {
-  test, expect, createModelHelpers,
-  fixturesDir
+  test, expect, fixturesDir
 } from '../fixtures.js'
+import { createModelHelpers } from '../../../utils/fixture-app.js'
+import { DitoUploadField } from '../../../utils/pages.js'
 import { AssetWidget } from '../models/AssetWidget.js'
 
-const { seed, saveAndFetch } = createModelHelpers(
+const { seed } = createModelHelpers(
   AssetWidget, 'asset-widgets'
 )
 
@@ -17,64 +18,32 @@ test.describe('single mode', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      await expect(
-        page.locator('.dito-upload').first()
-      ).toBeVisible({ timeout: 15_000 })
-
-      // Find the single-file upload component
-      const container = page.locator(
-        '.dito-upload:has(input#file)'
-      )
+      const upload = new DitoUploadField(page, 'file')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
       // Upload initial file
-      const responsePromise1 =
-        page.waitForResponse(
-          resp =>
-            resp.url().includes('/upload/') &&
-            resp.ok()
-        )
-      await container.locator(
-        'input[type="file"]'
-      ).setInputFiles(
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.png')
       )
-      await responsePromise1
 
       // Verify file row
-      await expect(
-        container.locator('tbody tr')
-      ).toHaveCount(1)
-      await expect(
-        container.locator('tbody tr')
-      ).toContainText('tiny.png')
+      await expect(upload.rows).toHaveCount(1)
+      await expect(upload.rows).toContainText('tiny.png')
 
       // Per-row upload button should exist
-      const rowUploadBtn = container.locator(
+      const rowUploadBtn = upload.container.locator(
         'tbody .dito-button--upload'
       )
       await expect(rowUploadBtn).toBeVisible()
 
       // Use per-row button to replace
-      const responsePromise2 =
-        page.waitForResponse(
-          resp =>
-            resp.url().includes('/upload/') &&
-            resp.ok()
-        )
-      await container.locator(
-        'input[type="file"]'
-      ).setInputFiles(
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.jpg')
       )
-      await responsePromise2
 
       // Should still have exactly 1 row
-      await expect(
-        container.locator('tbody tr')
-      ).toHaveCount(1)
-      await expect(
-        container.locator('tbody tr')
-      ).toContainText('tiny.jpg')
+      await expect(upload.rows).toHaveCount(1)
+      await expect(upload.rows).toContainText('tiny.jpg')
     }
   )
 
@@ -85,41 +54,19 @@ test.describe('single mode', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      await expect(
-        page.locator('.dito-upload').first()
-      ).toBeVisible({ timeout: 15_000 })
-
-      const container = page.locator(
-        '.dito-upload:has(input#file)'
-      )
+      const upload = new DitoUploadField(page, 'file')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
       // No file: footer upload button visible
-      await expect(
-        container.locator(
-          'tfoot .dito-button--upload'
-        )
-      ).toBeVisible()
+      await expect(upload.addButton).toBeVisible()
 
       // Upload a file
-      const responsePromise =
-        page.waitForResponse(
-          resp =>
-            resp.url().includes('/upload/') &&
-            resp.ok()
-        )
-      await container.locator(
-        'input[type="file"]'
-      ).setInputFiles(
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.png')
       )
-      await responsePromise
 
       // Footer upload button should be hidden
-      await expect(
-        container.locator(
-          'tfoot .dito-button--upload'
-        )
-      ).not.toBeVisible()
+      await expect(upload.addButton).not.toBeVisible()
     }
   )
 })

--- a/tests/e2e/assets/admin/upload.ts
+++ b/tests/e2e/assets/admin/upload.ts
@@ -1,8 +1,9 @@
 import path from 'path'
 import {
-  test, expect, createModelHelpers,
-  uploadFile, fixturesDir
+  test, expect, fixturesDir
 } from '../fixtures.js'
+import { createModelHelpers } from '../../../utils/fixture-app.js'
+import { DitoUploadField } from '../../../utils/pages.js'
 import { AssetWidget } from '../models/AssetWidget.js'
 
 const { seed, saveAndFetch } = createModelHelpers(
@@ -34,25 +35,15 @@ test.describe('upload', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      // Wait for the form to load — scope to
-      // the upload component for 'files' to avoid
-      // matching other upload components on the page.
-      // The id is on the hidden file input, not the
-      // .dito-upload root, so use :has() to scope.
-      const upload = page.locator(
-        '.dito-upload:has(input#files)'
-      )
-      await expect(upload).toBeVisible(
-        { timeout: 15_000 }
-      )
+      const upload = new DitoUploadField(page, 'files')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.png')
       )
 
       // Verify file row appears
-      const row = upload.locator('tbody tr').first()
+      const row = upload.getRow(0)
       await expect(row).toBeVisible()
       await expect(row).toContainText('tiny.png')
       await expect(row).toContainText('Uploaded')
@@ -66,38 +57,27 @@ test.describe('upload', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      const upload = page.locator(
-        '.dito-upload:has(input#files)'
-      )
-      await expect(upload).toBeVisible(
-        { timeout: 15_000 }
-      )
+      const upload = new DitoUploadField(page, 'files')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.png')
       )
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.jpg')
       )
 
-      const rows = upload.locator('tbody tr')
-      await expect(rows).toHaveCount(2)
-      await expect(rows.nth(0)).toContainText(
+      await expect(upload.rows).toHaveCount(2)
+      await expect(upload.getRow(0)).toContainText(
         'tiny.png'
       )
-      await expect(rows.nth(1)).toContainText(
+      await expect(upload.getRow(1)).toContainText(
         'tiny.jpg'
       )
 
       // Footer upload button always visible in
       // multiple mode
-      await expect(
-        upload.locator(
-          'tfoot .dito-button--upload'
-        )
-      ).toBeVisible()
+      await expect(upload.addButton).toBeVisible()
     }
   )
 
@@ -108,19 +88,13 @@ test.describe('upload', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      const upload = page.locator(
-        '.dito-upload:has(input#files)'
-      )
-      await expect(upload).toBeVisible(
-        { timeout: 15_000 }
-      )
+      const upload = new DitoUploadField(page, 'files')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.png')
       )
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.jpg')
       )
 
@@ -154,15 +128,10 @@ test.describe('upload', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      const upload = page.locator(
-        '.dito-upload:has(input#files)'
-      )
-      await expect(upload).toBeVisible(
-        { timeout: 15_000 }
-      )
+      const upload = new DitoUploadField(page, 'files')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
-      await uploadFile(
-        page,
+      await upload.upload(
         path.resolve(fixturesDir, 'tiny.png')
       )
       await saveAndFetch(page, widgetId)
@@ -171,11 +140,9 @@ test.describe('upload', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      await expect(upload).toBeVisible(
-        { timeout: 15_000 }
-      )
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
-      const row = upload.locator('tbody tr').first()
+      const row = upload.getRow(0)
       await expect(row).toContainText('Stored')
       await expect(row).not.toContainText(
         'Uploaded'

--- a/tests/e2e/assets/admin/validation.ts
+++ b/tests/e2e/assets/admin/validation.ts
@@ -1,8 +1,9 @@
 import path from 'path'
 import {
-  test, expect, createModelHelpers,
-  fixturesDir
+  test, expect, fixturesDir
 } from '../fixtures.js'
+import { createModelHelpers } from '../../../utils/fixture-app.js'
+import { DitoUploadField } from '../../../utils/pages.js'
 import { AssetWidget } from '../models/AssetWidget.js'
 
 const { seed } = createModelHelpers(
@@ -17,18 +18,15 @@ test.describe('validation', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      await expect(
-        page.locator('.dito-upload').first()
-      ).toBeVisible({ timeout: 15_000 })
+      // Upload .txt to the files component. Bypass DitoUploadField.upload()
+      // because the file is rejected client-side, so no /upload/ response
+      // ever fires for it to await.
+      const upload = new DitoUploadField(page, 'files')
+      await upload.waitUntilVisible({ timeout: 15_000 })
 
-      // Upload .txt to the files component
-      const upload = page.locator(
-        '.dito-upload:has(input#files)'
-      )
-      const fileInput = upload.locator(
+      await upload.container.locator(
         'input[type="file"]'
-      )
-      await fileInput.setInputFiles(
+      ).setInputFiles(
         path.resolve(fixturesDir, 'invalid.txt')
       )
 
@@ -44,9 +42,7 @@ test.describe('validation', () => {
       )
 
       // No file row should appear
-      await expect(
-        upload.locator('tbody tr')
-      ).toHaveCount(0)
+      await expect(upload.rows).toHaveCount(0)
     }
   )
 
@@ -57,20 +53,17 @@ test.describe('validation', () => {
       await page.goto(
         `${url}/admin/assets/${widgetId}`
       )
-      await expect(
-        page.locator('.dito-upload').first()
-      ).toBeVisible({ timeout: 15_000 })
-
       // Upload to the filesSmall component
       // (maxSize: 100b) — tiny.jpg (285b) exceeds
-      // this
-      const upload = page.locator(
-        '.dito-upload:has(input#filesSmall)'
-      )
-      const fileInput = upload.locator(
+      // this. Bypass DitoUploadField.upload() because
+      // the file is rejected client-side, so no
+      // /upload/ response ever fires.
+      const upload = new DitoUploadField(page, 'filesSmall')
+      await upload.waitUntilVisible({ timeout: 15_000 })
+
+      await upload.container.locator(
         'input[type="file"]'
-      )
-      await fileInput.setInputFiles(
+      ).setInputFiles(
         path.resolve(fixturesDir, 'tiny.jpg')
       )
 

--- a/tests/e2e/assets/fixtures.ts
+++ b/tests/e2e/assets/fixtures.ts
@@ -1,159 +1,109 @@
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
-import {
-  test as base,
-  expect
-} from '@playwright/test'
-import {
-  AdminController,
-  ModelController,
-  AssetModel
-} from '@ditojs/server'
-
-// AssetModel is created via a mixin and has an
-// empty .name, so we extend it to get a proper
-// named class that Application.addModels() can
-// register under the key 'Asset'.
-class Asset extends AssetModel {}
+import { test as base, expect } from '@playwright/test'
+import { AdminController, ModelController, AssetModel } from '@ditojs/server'
 import serve from 'koa-static'
 import mount from 'koa-mount'
 import {
-  createTestApp,
-  getAppUrl,
-  stubSession
-} from '../../utils/app.js'
-import {
-  createTestDatabase
-} from '../../utils/database.js'
-import { waitForUrl } from '../../utils/net.js'
+  startTestApp,
+  bootTestDb,
+  startAndWaitForAdmin,
+  teardownTestApp
+} from '../../utils/fixture-app.js'
 import { AssetWidget } from './models/AssetWidget.js'
 import { NestedAssetWidget } from './models/NestedAssetWidget.js'
 
+// AssetModel is created via a mixin and has an empty `.name`, so we extend
+// it to get a proper named class that Application.addModels() can register
+// under the key 'Asset'.
+class Asset extends AssetModel {}
+
 export { expect }
-export {
-  getInput,
-  getContainer
-} from '../../utils/admin.js'
+export { getInput, getContainer } from '../../utils/admin.js'
 
-export const fixturesDir = path.resolve(
-  import.meta.dirname, 'fixtures'
-)
+export const fixturesDir = path.resolve(import.meta.dirname, 'fixtures')
 
-// Worker-scoped fixture: one app per worker,
-// shared across all spec files in that worker.
-export const test = base.extend<
-  { url: string },
-  { workerUrl: string }
->({
-  workerUrl: [async ({}, use) => {
-    const tmpDir = await fs.mkdtemp(
-      path.join(
-        os.tmpdir(), 'dito-e2e-uploads-'
+// Worker-scoped fixture: one app per worker, shared across all spec files
+// in that worker. Uses the shared lifecycle primitives plus this scenario's
+// custom storage config + middleware mounts.
+export const test = base.extend<{ url: string }, { workerUrl: string }>({
+  workerUrl: [
+    async ({}, use) => {
+      const tmpDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'dito-e2e-uploads-')
       )
-    )
-
-    const app = createTestApp({
-      models: {
-        AssetWidget,
-        NestedAssetWidget,
-        Asset
-      },
-      admin: {
-        root: path.resolve(
-          import.meta.dirname, 'app'
-        ),
-        api: { url: '/api/' }
-      },
-      controllers: {
-        admin: AdminController,
-        api: {
-          AssetWidgets: class extends ModelController {
-            override modelClass = AssetWidget
-            collection = {
-              allow: ['get', 'post'] as const
-            }
-            member = {
-              allow: [
-                'get', 'patch', 'delete'
-              ] as const
-            }
-            assets = {
-              files: { storage: 'test' },
-              file: { storage: 'test' },
-              filesSmall: { storage: 'test' }
+      try {
+        const app = startTestApp({
+          appRoot: path.resolve(import.meta.dirname, 'app'),
+          models: { AssetWidget, NestedAssetWidget, Asset },
+          controllers: {
+            admin: AdminController,
+            api: {
+              AssetWidgets: class extends ModelController {
+                override modelClass = AssetWidget
+                collection = { allow: ['get', 'post'] as const }
+                member = {
+                  allow: ['get', 'patch', 'delete'] as const
+                }
+                assets = {
+                  files: { storage: 'test' },
+                  file: { storage: 'test' },
+                  filesSmall: { storage: 'test' }
+                }
+              },
+              NestedAssetWidgets: class extends ModelController {
+                override modelClass = NestedAssetWidget
+                collection = { allow: ['get', 'post'] as const }
+                member = {
+                  allow: ['get', 'patch', 'delete'] as const
+                }
+                assets = true
+              }
             }
           },
-          NestedAssetWidgets: class extends ModelController {
-            override modelClass = NestedAssetWidget
-            collection = {
-              allow: ['get', 'post'] as const
+          config: {
+            storages: {
+              test: {
+                type: 'disk',
+                path: tmpDir,
+                url: '/uploads',
+                allowedImports: [`file://${fixturesDir}/**`]
+              }
+            },
+            assets: {
+              cleanupTimeThreshold: '0s',
+              danglingTimeThreshold: '24h'
             }
-            member = {
-              allow: [
-                'get', 'patch', 'delete'
-              ] as const
-            }
-            assets = true
           }
+        })
+
+        // Serve uploaded files at /uploads, fixture files at /fixtures
+        // (for HTTP import tests). Mounts must run before app.start.
+        app.use(mount('/uploads', serve(tmpDir)))
+        app.use(mount('/fixtures', serve(fixturesDir)))
+
+        await bootTestDb(app)
+        const url = await startAndWaitForAdmin(app)
+
+        // Update storage config with the actual port. Storage._getUrl()
+        // requires an absolute base URL, and allowedImports uses the
+        // actual port for HTTP import tests (B12).
+        const storage = app.getStorage('test')
+        storage.url = `${url}/uploads`
+        storage.config.allowedImports.push(`${url}/fixtures/**`)
+
+        try {
+          await use(url)
+        } finally {
+          await teardownTestApp(app)
         }
-      },
-      config: {
-        storages: {
-          test: {
-            type: 'disk',
-            path: tmpDir,
-            url: '/uploads',
-            allowedImports: [
-              `file://${fixturesDir}/**`
-            ]
-          }
-        },
-        assets: {
-          cleanupTimeThreshold: '0s',
-          danglingTimeThreshold: '24h'
-        }
+      } finally {
+        await fs.rm(tmpDir, { recursive: true, force: true })
       }
-    })
-
-    stubSession(app)
-
-    // Serve uploaded files at /uploads
-    app.use(mount('/uploads', serve(tmpDir)))
-
-    // Serve fixture files at /fixtures (for
-    // HTTP import tests)
-    app.use(
-      mount('/fixtures', serve(fixturesDir))
-    )
-
-    await createTestDatabase(app)
-    await app.start()
-    const url = getAppUrl(app)
-
-    // Update storage config with actual port.
-    // Storage._getUrl() requires an absolute base
-    // URL, and allowedImports uses the actual port
-    // for HTTP import tests (B12).
-    const storage = app.getStorage('test')
-    storage.url = `${url}/uploads`
-    storage.config.allowedImports.push(
-      `${url}/fixtures/**`
-    )
-
-    await waitForUrl(`${url}/admin/`)
-    await use(url)
-    // Suppress errors during teardown — closing
-    // connections triggers expected "Premature
-    // close" errors from in-flight responses.
-    app.off('error', app.logError)
-    app.server?.closeAllConnections()
-    await app.stop()
-    await app.knex?.destroy()
-    await fs.rm(
-      tmpDir, { recursive: true, force: true }
-    )
-  }, { scope: 'worker' }],
+    },
+    { scope: 'worker' }
+  ],
 
   url: async ({ workerUrl }, use) => {
     await use(workerUrl)
@@ -161,41 +111,31 @@ export const test = base.extend<
 })
 
 /**
- * Upload a file via the server API and return
- * its metadata. Used by server and programmatic
- * tests that don't need a browser.
+ * Upload a file via the server API and return its metadata. Used by server
+ * and programmatic tests that don't need a browser.
  */
-export async function uploadViaApi(
-  url: string
-) {
-  const filePath = path.resolve(
-    fixturesDir, 'tiny.png'
-  )
+export async function uploadViaApi(url: string) {
+  const filePath = path.resolve(fixturesDir, 'tiny.png')
   const fileBuffer = await fs.readFile(filePath)
-  const file = new File(
-    [fileBuffer], 'tiny.png',
-    { type: 'image/png' }
-  )
+  const file = new File([fileBuffer], 'tiny.png', { type: 'image/png' })
   const form = new FormData()
   form.append('files', file)
 
-  const resp = await fetch(
-    `${url}/api/asset-widgets/upload/files`,
-    { method: 'POST', body: form }
-  )
+  const resp = await fetch(`${url}/api/asset-widgets/upload/files`, {
+    method: 'POST',
+    body: form
+  })
   const body = await resp.json()
   return body[0]
 }
 
 /**
- * Temporarily suppress server error logging
- * during a callback. Use this around operations
- * that are expected to trigger server errors
- * (e.g. invalid uploads, premature closes).
+ * Temporarily suppress server error logging during a callback. Use this
+ * around operations that are expected to trigger server errors (e.g.
+ * invalid uploads, premature closes).
  */
 export async function suppressErrors<T>(
-  app: { off: Function; on: Function;
-    logError: Function },
+  app: { off: Function; on: Function; logError: Function },
   fn: () => Promise<T>
 ): Promise<T> {
   const noop = () => {}

--- a/tests/e2e/assets/fixtures.ts
+++ b/tests/e2e/assets/fixtures.ts
@@ -1,7 +1,6 @@
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
-import type { Page } from '@playwright/test'
 import {
   test as base,
   expect
@@ -9,7 +8,6 @@ import {
 import {
   AdminController,
   ModelController,
-  Model,
   AssetModel
 } from '@ditojs/server'
 
@@ -161,91 +159,6 @@ export const test = base.extend<
     await use(workerUrl)
   }
 })
-
-export function createModelHelpers<
-  M extends typeof Model
->(
-  ModelClass: M,
-  resource: string,
-  defaults: Record<string, unknown> = {}
-) {
-  async function seed(
-    data: Record<string, unknown> = {}
-  ) {
-    const instance = await ModelClass.query()
-      .insert({ ...defaults, ...data })
-    return instance.$id() as number
-  }
-
-  async function saveAndFetch(
-    page: Page,
-    id: number
-  ): Promise<InstanceType<M>> {
-    const saved = page.waitForResponse(resp =>
-      resp.url().includes(
-        `/api/${resource}/${id}`
-      ) &&
-      resp.request().method() === 'PATCH' &&
-      resp.ok()
-    )
-    await page.locator(
-      'button.dito-button[type="submit"]'
-    ).first().click()
-    await saved
-    const instance = await ModelClass.query()
-      .findById(id)
-    if (!instance) {
-      throw new Error(
-        `${ModelClass.name} ${id} not found`
-      )
-    }
-    return instance as InstanceType<M>
-  }
-
-  return { seed, saveAndFetch }
-}
-
-/**
- * Upload a file to the upload component and
- * wait for the upload response.
- */
-export async function uploadFile(
-  page: Page,
-  filePath: string
-) {
-  const responsePromise = page.waitForResponse(
-    resp =>
-      resp.url().includes('/upload/') &&
-      resp.ok()
-  )
-  const fileInput = page.locator(
-    '.dito-upload input[type="file"]'
-  ).first()
-  await fileInput.setInputFiles(filePath)
-  await responsePromise
-}
-
-/**
- * Upload a file to a specific upload component
- * (identified by its container selector) and
- * wait for the upload response.
- */
-export async function uploadFileTo(
-  page: Page,
-  containerSelector: string,
-  filePath: string
-) {
-  const responsePromise = page.waitForResponse(
-    resp =>
-      resp.url().includes('/upload/') &&
-      resp.ok()
-  )
-  const fileInput = page.locator(
-    containerSelector
-  ).locator('input[type="file"]')
-  await fileInput.setInputFiles(filePath)
-  await responsePromise
-}
 
 /**
  * Upload a file via the server API and return

--- a/tests/utils/fixture-app.ts
+++ b/tests/utils/fixture-app.ts
@@ -1,4 +1,4 @@
-import { test as base, type Page } from '@playwright/test'
+import { test as base, type Browser, type Page } from '@playwright/test'
 import type { Model } from '@ditojs/server'
 import {
   createTestApp,
@@ -7,6 +7,68 @@ import {
 } from './app.js'
 import { createTestDatabase } from './database.js'
 import { waitForUrl } from './net.js'
+
+type TestApp = ReturnType<typeof createTestApp>
+
+interface StartTestAppOptions {
+  appRoot: string
+  models: Record<string, typeof Model>
+  controllers: Record<string, unknown>
+  config?: Record<string, unknown>
+}
+
+/** Create the embedded app + auth stub. Returns the unstarted app. */
+export function startTestApp(opts: StartTestAppOptions): TestApp {
+  const app = createTestApp({
+    models: opts.models,
+    controllers: opts.controllers,
+    admin: {
+      root: opts.appRoot,
+      api: { url: '/api/' }
+    },
+    config: opts.config
+  })
+  stubSession(app)
+  return app
+}
+
+/** Initialise the in-process PGlite schema from the app's models. */
+export async function bootTestDb(app: TestApp): Promise<void> {
+  await createTestDatabase(app)
+}
+
+/** Start the HTTP server and wait for /admin/ to respond. Returns the url. */
+export async function startAndWaitForAdmin(app: TestApp): Promise<string> {
+  await app.start()
+  const url = getAppUrl(app)
+  await waitForUrl(`${url}/admin/`)
+  return url
+}
+
+/** Visit `${url}${path}` once to warm the admin's Vite dev server so the
+ * first per-test navigation doesn't pay a cold-compile cost. */
+export async function warmAdmin(
+  browser: Browser,
+  url: string,
+  path: string
+): Promise<void> {
+  const page = await browser.newPage()
+  try {
+    await page.goto(`${url}${path}`, { waitUntil: 'networkidle' })
+  } finally {
+    await page.close()
+  }
+}
+
+/** Stop the server and release knex/connection resources. */
+export async function teardownTestApp(app: TestApp): Promise<void> {
+  // Suppress errors during teardown — closing connections triggers
+  // expected "Premature close" errors from in-flight responses.
+  app.off('error', app.logError)
+  app.server?.closeAllConnections()
+  await app.stop()
+  await app.knex?.destroy()
+}
 
 export interface FixtureAppOptions {
   /** Absolute path to the scenario's `app/` directory (the admin entrypoint). */
@@ -21,62 +83,36 @@ export interface FixtureAppOptions {
    * `${url}${warmupPath}` once after the app starts. Avoids first-test
    * cold-compile timeouts in CI. */
   warmupPath?: string
-  /** If set, runs after `createTestDatabase(app)` and before `app.start()`.
-   * Use this to create extra schema (e.g. join tables for many-to-many
-   * relations that `createTestDatabase` doesn't auto-derive). */
-  setupHook?: (app: ReturnType<typeof createTestApp>) => Promise<void>
+  /** If set, runs after `bootTestDb(app)` and before `app.start()`. Use this
+   * to create extra schema (e.g. join tables for many-to-many relations
+   * that `createTestDatabase` doesn't auto-derive). */
+  setupHook?: (app: TestApp) => Promise<void>
 }
 
 /**
  * Returns a Playwright test object whose worker fixture spins up an
  * embedded Dito app (PGlite-backed, Vite-served admin) and exposes its
- * `url`. Mirrors the boilerplate in `tests/e2e/assets/fixtures.ts`.
+ * `url`. Composes the primitives above; scenarios with unusual setup
+ * (custom storage, mounted middleware, etc.) compose them inline instead.
  */
 export function createFixtureAppFixture(opts: FixtureAppOptions) {
   return base.extend<{ url: string }, { workerUrl: string }>({
     workerUrl: [
       async ({ browser }, use) => {
-        const app = createTestApp({
-          models: opts.models,
-          controllers: opts.controllers,
-          admin: {
-            root: opts.appRoot,
-            api: { url: '/api/' }
-          },
-          config: opts.config
-        })
-
-        stubSession(app)
-        await createTestDatabase(app)
+        const app = startTestApp(opts)
+        await bootTestDb(app)
         if (opts.setupHook) {
           await opts.setupHook(app)
         }
-        await app.start()
-        const url = getAppUrl(app)
-        await waitForUrl(`${url}/admin/`)
-
+        const url = await startAndWaitForAdmin(app)
         if (opts.warmupPath) {
-          // Warm the admin Vite bundle once per worker so the first
-          // per-test navigation doesn't burn a per-test timeout on cold
-          // compile.
-          const page = await browser.newPage()
-          try {
-            await page.goto(`${url}${opts.warmupPath}`, {
-              waitUntil: 'networkidle'
-            })
-          } finally {
-            await page.close()
-          }
+          await warmAdmin(browser, url, opts.warmupPath)
         }
-
-        await use(url)
-
-        // Suppress errors during teardown — closing connections triggers
-        // expected "Premature close" errors from in-flight responses.
-        app.off('error', app.logError)
-        app.server?.closeAllConnections()
-        await app.stop()
-        await app.knex?.destroy()
+        try {
+          await use(url)
+        } finally {
+          await teardownTestApp(app)
+        }
       },
       { scope: 'worker' }
     ],
@@ -89,7 +125,6 @@ export function createFixtureAppFixture(opts: FixtureAppOptions) {
 
 /**
  * Returns `seed` and `saveAndFetch` helpers for a model + REST resource.
- * Relocated from `tests/e2e/assets/fixtures.ts`.
  */
 export function createModelHelpers<M extends typeof Model>(
   ModelClass: M,


### PR DESCRIPTION
Two commits, building on each other:

- **Tests: Migrate assets/ specs to use shared page-objects** — rewrite `tests/e2e/assets/admin/{upload,delete,drag-reorder,single-mode,validation}.ts` to consume `DitoForm`, `DitoList`, `DitoUploadField`. Delete `uploadFile`/`uploadFileTo` helpers and the duplicate `createModelHelpers` from `assets/fixtures.ts`.
- **Tests: Extract worker-fixture lifecycle primitives, use them in assets/** — split `tests/utils/fixture-app.ts` into reusable primitives (`startTestApp`, `bootTestDb`, `startAndWaitForAdmin`, `warmAdmin`, `teardownTestApp`). `createFixtureAppFixture` becomes sugar that composes them; assets's worker fixture composes the same primitives inline alongside its custom storage/mount/cleanup. No factory API growth.

Closes the original 6-MR e2e roadmap. Every browser-driven spec in `tests/e2e/` now uses the shared page-objects, and every worker fixture either uses the factory or composes the same primitives the factory uses.