### PR TITLE
Tests: Per-scenario Vite cache dir in createTestApp

### DIFF
--- a/tests/utils/app.ts
+++ b/tests/utils/app.ts
@@ -109,7 +109,11 @@ export function createTestApp(
         cacheDir: path.join(
           os.tmpdir(),
           'dito-e2e-vite-cache',
-          path.basename(options.admin!.root!)
+          // Use the parent directory name so each scenario gets its own
+          // cache. `path.basename(appRoot)` is `"app"` for every scenario
+          // (each one has `<scenario>/app/`), which collides and forces
+          // Vite to re-optimize deps on every fixture run.
+          path.basename(path.dirname(options.admin!.root!))
         )
       })
       app.loadAdminViteConfig =


### PR DESCRIPTION
Written by Claude.

`path.basename(appRoot)` returns `"app"` for every scenario (each scenario has `<scenario>/app/`), so all scenarios shared one Vite cache dir and forced re-optimization on every fixture run as the cache flipped between configs. Use the parent directory name instead — `crud`, `scopes`, etc. — so each scenario keeps its own cache.

## Verified locally

- Cold cache (first run): 14 re-optimization messages = 7 scenarios × 2 messages each. Expected — each scenario warms its own cache once.
- Warm cache (second run): 0 messages. Caches are preserved across runs instead of thrashing.

## Test plan

- [ ] Run `pnpm --filter @ditojs/tests test:e2e` once cold, observe per-scenario optimization on first run only
- [ ] Re-run and confirm no further "Re-optimizing dependencies" messages