### PR TITLE
Server: Infer property type from discriminator/oneOf in getProperty

### DIFF
--- a/packages/server/src/models/Model.js
+++ b/packages/server/src/models/Model.js
@@ -482,6 +482,25 @@ export class Model extends objection.Model {
         }
       }
     }
+    // `discriminator`/`oneOf`/`anyOf`/`allOf` schemas don't always carry an
+    // explicit top-level `type`, so callers checking `property.type` (e.g.
+    // `loadDataPath()`, which gates traversal of nested data paths on the
+    // root being object/array) reject them. Fill in the type when it can be
+    // inferred unambiguously: a `discriminator` implies an object, and a
+    // homogeneous `oneOf`/`anyOf`/`allOf` adopts its branches' shared type.
+    if (property && !property.type) {
+      if (property.discriminator) {
+        property = { ...property, type: 'object' }
+      } else {
+        const branches = property.oneOf || property.anyOf || property.allOf
+        const types = new Set(
+          branches?.map(branch => branch?.type).filter(Boolean)
+        )
+        if (types.size === 1) {
+          property = { ...property, type: [...types][0] }
+        }
+      }
+    }
     return property ?? null
   }
 

--- a/packages/server/src/models/Model.test.js
+++ b/packages/server/src/models/Model.test.js
@@ -66,3 +66,115 @@ describe('Model._mapAssetFiles: asset signing across data paths', () => {
     expect(json).toEqual({ name: 'no-files-here' })
   })
 })
+
+describe('Model.getProperty: type inference for $ref/discriminator schemas', () => {
+  function getProperty({ name, properties, definitions = {} }) {
+    return Model.getProperty.call(
+      { definition: { properties }, jsonSchema: { definitions } },
+      name
+    )
+  }
+
+  it('returns the property unchanged when it has an explicit type', () => {
+    expect(
+      getProperty({
+        name: 'name',
+        properties: { name: { type: 'string' } }
+      })
+    ).toEqual({ type: 'string' })
+  })
+
+  it('infers type: object from a discriminator on a $ref schema', () => {
+    const property = getProperty({
+      name: 'content',
+      properties: { content: { $ref: '#StoryContent' } },
+      definitions: {
+        '#StoryContent': {
+          discriminator: { propertyName: 'type' },
+          oneOf: [
+            { type: 'object', properties: { type: { const: 'a' } } },
+            { type: 'object', properties: { type: { const: 'b' } } }
+          ]
+        }
+      }
+    })
+    expect(property.type).toBe('object')
+    expect(property.discriminator).toEqual({ propertyName: 'type' })
+  })
+
+  it('infers a shared type from a homogeneous oneOf', () => {
+    const property = getProperty({
+      name: 'content',
+      properties: {
+        content: { oneOf: [{ type: 'object' }, { type: 'object' }] }
+      }
+    })
+    expect(property.type).toBe('object')
+  })
+
+  it('infers a shared type from a homogeneous anyOf', () => {
+    const property = getProperty({
+      name: 'content',
+      properties: {
+        content: { anyOf: [{ type: 'array' }, { type: 'array' }] }
+      }
+    })
+    expect(property.type).toBe('array')
+  })
+
+  it('leaves type undefined when oneOf branches disagree', () => {
+    const property = getProperty({
+      name: 'content',
+      properties: {
+        content: { oneOf: [{ type: 'object' }, { type: 'string' }] }
+      }
+    })
+    expect(property.type).toBeUndefined()
+  })
+
+  it('returns null for an unknown property', () => {
+    expect(getProperty({ name: 'missing', properties: {} })).toBeNull()
+  })
+})
+
+describe('Model.getPropertyOrRelationAtDataPath: traversal through inferred types', () => {
+  function lookup({ dataPath, properties, definitions = {} }) {
+    const host = {
+      definition: { properties },
+      jsonSchema: { definitions },
+      getRelations: () => ({}),
+      getProperty(name) {
+        return Model.getProperty.call(this, name)
+      }
+    }
+    return Model.getPropertyOrRelationAtDataPath.call(host, dataPath)
+  }
+
+  it('exposes object type for a discriminator-rooted nested wildcard path', () => {
+    // Reproduces the original loadDataPath() crash on
+    // `content.article.items[**].file`: before the fix, `content` had
+    // no resolved `type`, so loadDataPath rejected the nested path.
+    const result = lookup({
+      dataPath: 'content.article.items[**].file',
+      properties: { content: { $ref: '#StoryContent' } },
+      definitions: {
+        '#StoryContent': {
+          discriminator: { propertyName: 'type' },
+          oneOf: [{ type: 'object' }]
+        }
+      }
+    })
+    expect(result.property.type).toBe('object')
+    expect(result.nestedDataPath).toBe('article/items/**/file')
+    expect(result.dataPath).toBe('content')
+  })
+
+  it('returns no nestedDataPath for a leaf property lookup', () => {
+    const result = lookup({
+      dataPath: 'name',
+      properties: { name: { type: 'string' } }
+    })
+    expect(result.property).toEqual({ type: 'string' })
+    expect(result.nestedDataPath).toBe('')
+  })
+})


### PR DESCRIPTION
Written by Claude.

## Problem

`Model.getProperty(name)` resolves `$ref` schemas but doesn't infer a top-level `type` when the resolved definition uses JSON Schema constructs that imply a type without stating one explicitly. Concretely, deleting a row whose model has an asset path like `content.article.items[**].file` blows up at `QueryBuilder.loadDataPath()`:

```
QueryBuilderError: Unable to load full data-path 'content.article.items[**].file' (Unmatched: 'article/items/**/file').
```

The check in `loadDataPath()` requires `property.type` to be `'object'` or `'array'` (or a wildcard) to traverse a nested data path. When `content` is defined as:

```js
{
  $ref: '#StoryContent',
  definitions: {
    '#StoryContent': {
      discriminator: { propertyName: 'type' },
      oneOf: [/* { type: 'object', ... }, ... */]
    }
  }
}
```

`getProperty()` resolves the `$ref` but the merged property has `discriminator + oneOf` and no `type` — so the check fails.

## Fix

Extend `getProperty()` to fill in the missing `type` when it can be inferred unambiguously:

- A `discriminator` implies `type: 'object'` (per JSON Schema / OpenAPI semantics).
- A homogeneous `oneOf` / `anyOf` / `allOf` adopts its branches' shared type.

This is additive — existing properties with explicit `type` are unchanged. Any caller that previously branched on `property.type === undefined` for these schemas will now see the inferred type, which is what they would have expected if the schema author had spelled it out.

## Test plan

- [x] `pnpm vitest run packages/server/src/models/Model.test.js` — 6 new unit tests cover explicit type, discriminator-on-$ref, homogeneous oneOf/anyOf, mixed oneOf, missing property
- [x] CI green (lint + unit + e2e)