### PR TITLE
Tests: Disable Vite depsOptimizer discovery in createTestApp

### DIFF
--- a/tests/utils/app.ts
+++ b/tests/utils/app.ts
@@ -44,20 +44,17 @@ export function createTestApp(
   }) as TestApp
 
   if (options.admin) {
-    // Resolve @ditojs/admin and @ditojs/ui from source
-    // so no prior build step is needed. Their package
-    // exports point to dist/, but in dev we want to use
-    // source directly. @ditojs/utils already exports
-    // from src/ so no alias needed.
+    // Resolve @ditojs/admin and @ditojs/ui from source so no prior build step
+    // is needed. Their package exports point to dist/, but in dev we want to
+    // use source directly. @ditojs/utils already exports from src/ so no alias
+    // needed.
     const pkgs = path.resolve(
       import.meta.dirname, '../../packages'
     )
 
-    // After setup() registers controllers but before
-    // the vite dev server starts, build a vite config
-    // with our source aliases and make
-    // loadAdminViteConfig() return it so
-    // setupViteServer() uses it directly.
+    // After setup() registers controllers but before the vite dev server
+    // starts, build a vite config with our source aliases and make
+    // loadAdminViteConfig() return it so setupViteServer() uses it directly.
     app.once('before:start', () => {
       const viteConfig = app.defineAdminViteConfig({
         server: {
@@ -106,13 +103,21 @@ export function createTestApp(
             }
           }
         },
+        // Skip the depsOptimizer discovery scan so vite doesn't dispatch
+        // background `resolveId`/`load`/`transform` calls during startup.  The
+        // scan's in-flight promises aren't canceled by `discover.cancel()` at
+        // teardown (vite 8) and stay stuck in `pluginContainer._processesing`,
+        // making `pluginContainer.close()` hang indefinitely on workers that
+        // never visit /admin/ (e.g. programmatic-only playwright workers).
+        // Same workaround vitest applies for tests, see vitest commit e379f64.
+        optimizeDeps: { noDiscovery: true, include: [] },
         cacheDir: path.join(
           os.tmpdir(),
           'dito-e2e-vite-cache',
-          // Use the parent directory name so each scenario gets its own
-          // cache. `path.basename(appRoot)` is `"app"` for every scenario
-          // (each one has `<scenario>/app/`), which collides and forces
-          // Vite to re-optimize deps on every fixture run.
+          // Use the parent directory name so each scenario gets its own cache.
+          // `path.basename(appRoot)` is `"app"` for every scenario (each one
+          // has `<scenario>/app/`), which collides and forces Vite to
+          // re-optimize deps on every fixture run.
           path.basename(path.dirname(options.admin!.root!))
         )
       })


### PR DESCRIPTION
Written by Claude.

Fixes a `Fixture "workerUrl" timeout of 60000ms exceeded during teardown` flake hit on programmatic-only Playwright workers (e.g. `assets/programmatic/*.ts`).

## Root cause

Vite's `pluginContainer.close()` (`vite/dist/node/chunks/node.js:30192`) does:

```js
async close() {
    if (this._closed) return;
    this._closed = true;
    await Promise.allSettled(Array.from(this._processesing));   // ← hangs here
    await this.hookParallel("buildEnd", ...);                    // never reached
    await this.hookParallel("closeBundle", ...);
}
```

`_processesing` contains in-flight `resolveId` / `load` / `transform` calls dispatched by the depsOptimizer's startup scan. When `discover.cancel()` runs at teardown, the cancel does **not** propagate to those calls — they stay unsettled and `Promise.allSettled` waits forever.

Workers that never visit `/admin/` (programmatic-only suites) finish their tests fast and tear down while the scan is still in flight, triggering the hang.

## Fix

`optimizeDeps: { noDiscovery: true, include: [] }` — skip the discovery scan entirely. No scan = nothing in flight at teardown = no hang.

Same workaround vitest applies for the same reason: [vitest commit e379f64](https://github.com/vitest-dev/vitest/commit/e379f64a834f314d9d68b38e43d2307db423a4d3) "fix: disable optimizeDeps when running tests". Closest open vite issue is [vite#18224](https://github.com/vitejs/vite/issues/18224) (`p2-edge-case`, still open). The maintainers have acknowledged depsOptimizer cleanup is a hole in `server.close()`.

`include: []` is a no-op merge against the AdminController's existing include list (assignDeeply on arrays is positional), so explicit pre-bundles still apply.

## Verified

10 cold-cache local runs (cleared `dito-e2e-vite-cache` before each), all clean — no `Failed worker` and 0 `Re-optimizing dependencies` messages.

## Test plan

- [ ] Run `pnpm --filter @ditojs/tests test:e2e` cold and confirm no teardown timeout
- [ ] Re-run warm and confirm no regressions