### PR TITLE
Tests: Rename assets itemLabel to avoid collision with property key

### DIFF
--- a/tests/e2e/assets/app/views/index.ts
+++ b/tests/e2e/assets/app/views/index.ts
@@ -7,7 +7,7 @@ import { createWidgetView } from
   '../../../schema-components/app/views/createWidgetView.js'
 
 export const assets = createWidgetView<AssetWidget>(
-  'files',
+  'Asset Widget',
   'asset-widgets',
   {
     files: {


### PR DESCRIPTION
Written by Claude.

The assets test scenario passes `'files'` as `itemLabel` to `createWidgetView`. Since `'files'` is also a property on `AssetWidget`, dito's `getItemLabel` (`packages/admin/src/mixins/ItemMixin.js:103-117`) treats it as a property key rather than a literal label and returns `item.files`, which is the uploaded-files Array.

That Array then flows through `DitoForm.itemLabel` → `DitoFormInner.label`, where the prop is declared `type: String`. Vue's prop validation logs a warning, which Vite's HMR `sendLog` helper passes to `String([reactive proxy])` — that throws `Cannot convert object to primitive value`, killing the form render. Result: `e2e/assets/admin/upload.ts:29 'single file appears in table'` reproducibly fails, the form mounts as `<form><div class="dito-schema"><!--v-if--></div></form>`, no upload field is ever rendered.

`'Asset Widget'` doesn't match a property name, so the `isString(itemLabel) && !(itemLabel in item)` branch (line 103) treats it as a literal label string. Crud uses `'Widget'` for the same reason — works fine there.

## Verified

- `pnpm exec playwright test --grep "single file appears in table"` — passes in 641ms (was 15s timeout)
- Full assets suite cold cache — 59/59 passing in 21.4s

## Test plan

- [ ] Run `pnpm --filter @ditojs/tests test:e2e` — all assets admin/upload tests pass