### PR TITLE
Admin: Reject non-primitive itemLabel property values

### DIFF
--- a/packages/admin/src/mixins/ItemMixin.js
+++ b/packages/admin/src/mixins/ItemMixin.js
@@ -6,7 +6,7 @@ import {
   isListSource
 } from '../utils/schema.js'
 import { appendDataPath } from '../utils/data.js'
-import { isObject, isString, isFunction } from '@ditojs/utils'
+import { isObject, isString, isNumber, isFunction } from '@ditojs/utils'
 
 // @vue/component
 export default {
@@ -114,7 +114,10 @@ export default {
           isListSource(sourceSchema) && columns && Object.keys(columns)[0] ||
           'name'
         )
-        text = item[key]
+        const value = item[key]
+        // Only primitives display as a label. If the property holds an array
+        // or object, fall through to the auto-generated label.
+        text = isString(value) || isNumber(value) ? value : null
       }
       const hadLabel = !!text
       // If no label was found so far, try to produce one from the index.


### PR DESCRIPTION
Written by Claude.

`getItemLabel` (`packages/admin/src/mixins/ItemMixin.js`) has a property-key fallback that takes whatever `item[key]` returns:

```js
const key = (
  isString(itemLabel) && itemLabel ||
  isListSource(sourceSchema) && columns && Object.keys(columns)[0] ||
  'name'
)
text = item[key]   // could be anything — array, object, function
```

The implicit contract is "produces a value usable as the `label` prop on `DitoFormInner` (typed `String`)", but nothing enforces it. If the property happens to hold an Array or Object — easy when the model property name and `itemLabel` collide — that flows into the Vue prop. Vue's prop validation then runs `String(reactive proxy)`, throws `Cannot convert object to primitive value`, and the form render dies silently. Symptom we hit: `e2e/assets/admin/upload.ts:29 'single file appears in table'` reproduces the form mounting empty (`<form><div class="dito-schema"><!--v-if--></div></form>`).

## Fix

Only accept string and number from the property lookup; otherwise fall through to the auto-generated label (index, etc.):

```js
const value = item[key]
text = isString(value) || isNumber(value) ? value : null
```

## Verified

The assets test schema uses `itemLabel: 'files'`, which collides with `AssetWidget.files`. Before this PR, that produces a 100% reproducible failure on `e2e/assets/admin/upload.ts:29`. After this PR:

- `pnpm --filter @ditojs/tests test:e2e` cold cache: 59/59 passing in 21.6s
- The schema rename in PR #174 is no longer needed; that PR can be closed in favor of this one.

## Test plan

- [ ] Run `pnpm --filter @ditojs/tests test:e2e` — full suite green
- [ ] Sanity-check existing admin scenarios that already use string-typed `itemLabel` properties — no behavior change expected