### PR TITLE
Admin: Add ResourceMixin dirty-guard for in-flight GETs

### DIFF
--- a/packages/admin/src/components/DitoForm.vue
+++ b/packages/admin/src/components/DitoForm.vue
@@ -359,6 +359,14 @@ export default DitoComponent.component('DitoForm', {
       this.setData(null)
     },
 
+    // @override ResourceMixin.shouldApplyLoadedData()
+    shouldApplyLoadedData() {
+      // Drop a GET response if the user has made local edits while the
+      // request was in flight — applying it would wholesale-replace
+      // `loadedData` and silently clobber those edits.
+      return !this.isDirty
+    },
+
     // @override ResourceMixin.setData()
     setData(data) {
       // setData() is called after submit when data has changed.

--- a/packages/admin/src/mixins/ResourceMixin.js
+++ b/packages/admin/src/mixins/ResourceMixin.js
@@ -161,6 +161,13 @@ export default {
     },
 
     // @overridable
+    // Subclasses override this to skip applying response data when local
+    // state would be overwritten — see DitoForm, which checks `isDirty`.
+    shouldApplyLoadedData() {
+      return true
+    },
+
+    // @overridable
     setData(data) {
       this.loadedData = data
     },
@@ -217,7 +224,13 @@ export default {
             }
           }
         } else {
-          this.setData(response.data)
+          // Skip applying response data when the consumer (e.g. a dirty
+          // DitoForm) reports it would overwrite local edits made while the
+          // GET was in flight. The 'load' event still fires — the GET *did*
+          // complete; we just chose not to apply it.
+          if (this.shouldApplyLoadedData()) {
+            this.setData(response.data)
+          }
           this.emitSchemaEvent('load')
         }
       })

--- a/tests/e2e/route-refetch-race/admin/index.spec.ts
+++ b/tests/e2e/route-refetch-race/admin/index.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect, Widget } from '../fixtures.js'
+import { DitoListView, DitoForm } from '../../../utils/pages.js'
+
+test.describe('route-refetch-race', () => {
+  test('dirty form drops in-flight reload response so local edits survive', async ({
+    page,
+    url
+  }) => {
+    // Seed: a single widget. The items relation is wired up in the view but
+    // unused here — the bug is framework-level (ResourceMixin.requestData)
+    // and lives on the `DitoForm` itself, not on the items list.
+    const widget = await Widget.query().insertGraph({
+      name: 'before',
+      items: [{ label: 'item-one' }]
+    })
+
+    const list = new DitoListView(page, url, 'Widget')
+    const form = new DitoForm(page)
+
+    await list.navigate('/widgets')
+    await list.list.edit('before')
+
+    // Hold the *next* member GET on `/api/widgets/<id>`. The form's initial
+    // GET (fired by ResourceMixin's `created` hook → `setupData` →
+    // `ensureData` → `loadData(true)`) has already settled by the time the
+    // row is editable, so this handler picks up only the reload below.
+    let releaseGet!: () => void
+    const editPerformed = new Promise<void>(resolve => {
+      releaseGet = resolve
+    })
+    let pendingGet = false
+    await page.route(/\/api\/widgets\/\d+(\?|$)/, async (route, req) => {
+      // `\d+(\?|$)` boundary already excludes `/api/widgets/<id>/items[...]`,
+      // but assert it explicitly to avoid surprises.
+      if (/\/items/.test(req.url())) {
+        await route.continue()
+        return
+      }
+      if (req.method() === 'GET' && !pendingGet) {
+        pendingGet = true
+        await editPerformed
+      }
+      await route.continue()
+    })
+
+    // Drive `reloadData()` on the widget form directly. The bug we're fixing
+    // is in `ResourceMixin.requestData`'s success branch — it unconditionally
+    // calls `setData(response.data)`, clobbering any local edits made while
+    // the GET was in flight. We don't need to reproduce the exact user-level
+    // trigger (lineto's cancel-back from a `mutate: true` tree-list sub-form)
+    // — exercising `reloadData()` directly tests the framework boundary that
+    // the dirty-guard fix lives on.
+    //
+    // Access route: the Vue 3 app instance hangs off `el.__vue_app__`, and
+    // Vue exposes the active component for each DOM node on
+    // `__vueParentComponent`. Walk up from the form's root DOM until we hit
+    // a node whose `isForm === true` — that's the DitoForm.
+    await page.evaluate(() => {
+      const root = document.querySelector('.dito-form')
+      if (!root) throw new Error('No .dito-form in the DOM')
+      let node = (root as any).__vueParentComponent
+      while (node && !node.ctx?.isForm) node = node.parent
+      if (!node) throw new Error('Could not locate DitoForm component')
+      node.ctx.reloadData()
+    })
+
+    // Make a local edit while the held GET response sits in the request
+    // pipeline. Without the fix, the response will land on top of this and
+    // overwrite `loadedData.name` back to 'before'. With the fix, the form
+    // is dirty (`isDirty` true) so `shouldApplyLoadedData()` returns false
+    // and the response is discarded.
+    await form.fill('Name', 'after')
+
+    releaseGet()
+
+    // Save: the PATCH body carries whatever is currently in `loadedData`.
+    // With the bug: 'before'. With the fix: 'after'.
+    await form.save()
+
+    const saved = await Widget.query().findById(widget.$id() as number)
+    expect(saved?.name).toBe('after')
+  })
+})

--- a/tests/e2e/route-refetch-race/app/index.html
+++ b/tests/e2e/route-refetch-race/app/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <style>body, html { height: 100%; margin: 0; }</style>
+  </head>
+  <body>
+    <div id="dito-admin"></div>
+    <script type="module" src="/index.ts"></script>
+  </body>
+</html>

--- a/tests/e2e/route-refetch-race/app/index.ts
+++ b/tests/e2e/route-refetch-race/app/index.ts
@@ -1,0 +1,7 @@
+import DitoAdmin from '@ditojs/admin'
+import '@ditojs/admin/style.css'
+
+new DitoAdmin('#dito-admin', {
+  dito,
+  views: import('./views/index.js')
+})

--- a/tests/e2e/route-refetch-race/app/views/index.ts
+++ b/tests/e2e/route-refetch-race/app/views/index.ts
@@ -1,0 +1,35 @@
+import type { Widget } from '../../models/Widget.js'
+import { createWidgetView } from
+  '../../../schema-components/app/views/createWidgetView.js'
+
+export const widgets = createWidgetView<Widget>(
+  'Widget',
+  'widgets',
+  {
+    name: { type: 'text', label: 'Name' },
+    // The items list has its own `resource` (Items controller). With a
+    // resource attached, the sub-form's Save fires a real PATCH against
+    // `/api/items/:id`, and `ResourceMixin.submitResource` sets
+    // `parentMeta.reload = true` on the Widget form's route record. No
+    // `inlined: true`, so each item edit lives on its own route — that
+    //'s what makes the cancel-back navigate `from.path.startsWith(to.path)`
+    // and trigger SourceMixin's reload watcher.
+    items: {
+      type: 'list',
+      label: 'Items',
+      resource: { path: 'items' },
+      creatable: true,
+      editable: true,
+      form: {
+        type: 'form',
+        components: {
+          label: { type: 'text', label: 'Label' }
+        }
+      }
+    }
+  },
+  {
+    creatable: true,
+    columns: { name: { label: 'Name' } }
+  }
+)

--- a/tests/e2e/route-refetch-race/fixtures.ts
+++ b/tests/e2e/route-refetch-race/fixtures.ts
@@ -1,0 +1,81 @@
+import path from 'path'
+import { AdminController, ModelController } from '@ditojs/server'
+import {
+  createFixtureAppFixture,
+  createModelHelpers
+} from '../../utils/fixture-app.js'
+import { Item } from './models/Item.js'
+import { Widget } from './models/Widget.js'
+
+export { expect } from '@playwright/test'
+export { createModelHelpers, Item, Widget }
+
+class Widgets extends ModelController {
+  override modelClass = Widget
+  // `^withItems` forces the model's `withItems` scope on every query so
+  // GET /api/widgets/:id re-hydrates the items relation. `graph = true`
+  // switches PATCH/POST to the graph variants so `items: [...]` in the
+  // body actually inserts/updates Item rows (combined with `owner: true`
+  // on the relation).
+  override scope = ['^withItems']
+  override graph = true
+  collection = {
+    allow: ['get', 'post'] as const
+  }
+  member = {
+    allow: ['get', 'patch', 'delete'] as const
+  }
+  // Expose the items relation as a nested REST resource on Widgets so
+  // GET/PATCH /api/widgets/:id/items/:id work — the route nesting is
+  // what lets SourceMixin's `from.path.startsWith(to.path)` watcher
+  // trigger when cancelling back from a non-inlined item sub-form.
+  // Disable `graph` on the relation: it inherits from Widgets, but
+  // upsertGraph through `$relatedQuery` collides with the parent's
+  // findById filter ("upsertGraph query should contain no other query
+  // builder calls"). A plain member patch is what we want anyway.
+  override relations = {
+    items: {
+      graph: false,
+      relation: { allow: ['get', 'post'] as const },
+      member: { allow: ['get', 'patch', 'delete'] as const }
+    }
+  }
+}
+
+class Items extends ModelController {
+  override modelClass = Item
+  collection = {
+    allow: ['get', 'post'] as const
+  }
+  member = {
+    allow: ['get', 'patch', 'delete'] as const
+  }
+}
+
+export const test = createFixtureAppFixture({
+  appRoot: path.resolve(import.meta.dirname, 'app'),
+  models: { Widget, Item },
+  controllers: {
+    admin: AdminController,
+    api: { Widgets, Items }
+  },
+  warmupPath: '/admin/widgets'
+}).extend<{ resetState: void }>({
+  // Auto-runs before every test. Tests share one PGlite DB per worker
+  // (Playwright runs in-file tests sequentially), so reset before each.
+  // Order: clear Item first (FK to Widget), then Widget.
+  //
+  // The `url: _url` parameter looks unused but isn't — Playwright
+  // fixtures only initialize on request, and naming `url` here triggers
+  // the worker fixture chain that boots the embedded app and binds
+  // models to in-process knex. The `_` prefix tells the linter it's
+  // intentional.
+  resetState: [
+    async ({ url: _url }, use) => {
+      await Item.query().delete()
+      await Widget.query().delete()
+      await use()
+    },
+    { auto: true }
+  ]
+})

--- a/tests/e2e/route-refetch-race/models/Item.ts
+++ b/tests/e2e/route-refetch-race/models/Item.ts
@@ -1,0 +1,18 @@
+import type { ModelProperties } from '@ditojs/server'
+import { Model } from '@ditojs/server'
+
+export interface Item {
+  id: number
+  widgetId: number
+  label: string
+}
+
+export class Item extends Model {
+  static override properties: ModelProperties = {
+    // `widgetId` is nullable in the schema because Dito's graph save sets
+    // it on inserted children from the parent relation — the request body
+    // doesn't carry it.
+    widgetId: { type: 'integer', index: true, nullable: true },
+    label: { type: 'string', required: true }
+  }
+}

--- a/tests/e2e/route-refetch-race/models/Widget.ts
+++ b/tests/e2e/route-refetch-race/models/Widget.ts
@@ -1,0 +1,37 @@
+import type { ModelProperties, RelationMappings } from '@ditojs/server'
+import { Model } from '@ditojs/server'
+import type { QueryBuilder } from 'objection'
+import { Item } from './Item.js'
+
+export interface Widget {
+  id: number
+  name: string
+  items?: Item[]
+}
+
+export class Widget extends Model {
+  static override properties: ModelProperties = {
+    name: { type: 'string', required: true }
+  }
+
+  static override relations: RelationMappings = {
+    items: {
+      relation: 'hasMany',
+      from: 'Widget.id',
+      to: 'Item.widgetId',
+      // `owner: true` tells Dito the parent fully owns the children, so a
+      // graph save inserts/updates/deletes child rows with their data
+      // (label, etc.) rather than treating incoming items as relate-by-id
+      // references.
+      owner: true
+    }
+  }
+
+  static override scopes = {
+    // Eager-load items so the admin form re-hydrates the nested list on
+    // edit reload. Applied as `^withItems` on the Widgets controller in
+    // fixtures.ts so every query goes through this scope.
+    withItems: (query: QueryBuilder<Widget>) =>
+      query.withGraphFetched('items')
+  }
+}


### PR DESCRIPTION
Written by Claude.

- GET responses replacing `loadedData` on a dirty DitoForm clobbered local edits
- Add `shouldApplyLoadedData()` hook on `ResourceMixin`, default `true`
- Gate `setData(response.data)` in `requestData` on the hook
- Override in `DitoForm` to return `!this.isDirty`
- E2e regression in `tests/e2e/route-refetch-race/`