### PR TITLE
Admin: Inline isForm/isDirty check, drop shouldApplyLoadedData

### DIFF
--- a/packages/admin/src/components/DitoForm.vue
+++ b/packages/admin/src/components/DitoForm.vue
@@ -66,12 +66,15 @@ export default DitoComponent.component('DitoForm', {
     return {
       createdData: null,
       clonedData: undefined,
-      sourceKey: null,
-      isForm: true
+      sourceKey: null
     }
   },
 
   computed: {
+    isForm() {
+      return true
+    },
+
     verbs() {
       // Add submit / submitted to the verbs returned by ResourceMixin
       // NOTE: These get passed on to children through:
@@ -357,14 +360,6 @@ export default DitoComponent.component('DitoForm', {
     // @override ResourceMixin.clearData()
     clearData() {
       this.setData(null)
-    },
-
-    // @override ResourceMixin.shouldApplyLoadedData()
-    shouldApplyLoadedData() {
-      // Drop a GET response if the user has made local edits while the
-      // request was in flight — applying it would wholesale-replace
-      // `loadedData` and silently clobber those edits.
-      return !this.isDirty
     },
 
     // @override ResourceMixin.setData()

--- a/packages/admin/src/mixins/ResourceMixin.js
+++ b/packages/admin/src/mixins/ResourceMixin.js
@@ -161,13 +161,6 @@ export default {
     },
 
     // @overridable
-    // Subclasses override this to skip applying response data when local
-    // state would be overwritten — see DitoForm, which checks `isDirty`.
-    shouldApplyLoadedData() {
-      return true
-    },
-
-    // @overridable
     setData(data) {
       this.loadedData = data
     },
@@ -224,11 +217,11 @@ export default {
             }
           }
         } else {
-          // Skip applying response data when the consumer (e.g. a dirty
-          // DitoForm) reports it would overwrite local edits made while the
-          // GET was in flight. The 'load' event still fires — the GET *did*
-          // complete; we just chose not to apply it.
-          if (this.shouldApplyLoadedData()) {
+          // Skip applying response data on a dirty form: `setData` would
+          // wholesale-replace `loadedData` and clobber any local edits the
+          // user made while the GET was in flight. The `'load'` event still
+          // fires — the GET *did* complete; we just chose not to apply it.
+          if (!(this.isForm && this.isDirty)) {
             this.setData(response.data)
           }
           this.emitSchemaEvent('load')

--- a/packages/admin/src/mixins/RouteMixin.js
+++ b/packages/admin/src/mixins/RouteMixin.js
@@ -64,6 +64,10 @@ export default {
       return this.meta.nested
     },
 
+    isForm() {
+      return false
+    },
+
     isView() {
       return false
     },


### PR DESCRIPTION
- Drop the `shouldApplyLoadedData` method added in v2.99.0
- Gate `setData` in `requestData` on `!(this.isForm && this.isDirty)`
- Promote `isForm` to a computed default on `RouteMixin` (returns `false`)
- Move `DitoForm`'s `isForm` from data to a computed (returns `true`)